### PR TITLE
Use root mapping instead of root client list

### DIFF
--- a/service/isiService.go
+++ b/service/isiService.go
@@ -427,6 +427,22 @@ func (svc *isiService) RemoveExportClientByIDWithZone(exportID int, accessZone, 
 	return nil
 }
 
+func (svc *isiService) EnableRootMappingByIDWithZone(exportID int, accessZone, clientIP string) error {
+	log.Debugf("EnableRootMappingByIDWithZone client '%s'", clientIP)
+	if err := svc.client.EnableRootMappingByIDWithZone(context.Background(), exportID, accessZone, "nobody"); err != nil {
+		return fmt.Errorf("failed to enable root user to nobody mapping for export id '%d' : '%s'", exportID, err.Error())
+	}
+	return nil
+}
+
+func (svc *isiService) DisableRootMappingByIDWithZone(exportID int, accessZone, clientIP string) error {
+	log.Debugf("DisableRootMappingByIDWithZone client '%s'", clientIP)
+	if err := svc.client.DisableRootMappingByIDWithZone(context.Background(), exportID, accessZone); err != nil {
+		return fmt.Errorf("failed to disable root user mapping for export id '%d' : '%s'", exportID, err.Error())
+	}
+	return nil
+}
+
 func (svc *isiService) GetExportsWithLimit(limit string) (isi.ExportList, string, error) {
 	log.Debug("begin getting exports for Isilon")
 	var exports isi.Exports


### PR DESCRIPTION
This PR removes management of the root client list on an Isilon export, and replaces it with regular client list management plus disabling/enabling root mapping.

To compile, the following change in goisilon is required: https://github.com/dell/goisilon/pull/5

The change was motivated by the fact that limiting the root clients is not enough to block access to an export: If the client list is empty, Isilon NFS exports default to an allow-all rule. So, the client list must always be set, independent of the root client list.

It's possible the above also applies to the readonly client list, I didn't investigate that part.

Additionally, instead of managing both lists, the default root mapping on the export is disabled when the `rootClientEnabled` flag is set. When the flag is not set, the default root -> nobody mapping is installed.

Since the `OtherClientsAlreadyAdded` function doesn't differentiate between different modes and simply combines the client lists, there's no change necessary there.

We haven't tested the changes yet, but some feedback would be very valuable. Does the approach make sense, or should I consider managing both client lists instead?