### PR TITLE
Support for SINGLE_NODE_SINGLE_WRITER and SINGLE_NODE_MULTI_WRITER in csi-powerscale driver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,9 @@ module github.com/dell/csi-isilon
 require (
 	github.com/Showmax/go-fqdn v1.0.0
 	github.com/akutz/gournal v0.5.0
-	github.com/container-storage-interface/spec v1.4.0
+	github.com/container-storage-interface/spec v1.5.0
 	github.com/cucumber/godog v0.10.0
-	github.com/dell/gocsi v1.4.0
+	github.com/dell/gocsi v1.4.1-0.20211014153731-e18975a3a38c
 	github.com/dell/gofsutil v1.6.0
 	github.com/dell/goisilon v1.5.0
 	github.com/fsnotify/fsnotify v1.4.9

--- a/go.sum
+++ b/go.sum
@@ -64,8 +64,8 @@ github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDk
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/container-storage-interface/spec v1.2.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
-github.com/container-storage-interface/spec v1.4.0 h1:ozAshSKxpJnYUfmkpZCTYyF/4MYeYlhdXbAvPvfGmkg=
-github.com/container-storage-interface/spec v1.4.0/go.mod h1:6URME8mwIBbpVyZV93Ce5St17xBiQJQY67NDsuohiy4=
+github.com/container-storage-interface/spec v1.5.0 h1:lvKxe3uLgqQeVQcrnL2CPQKISoKjTJxojEs9cBk+HXo=
+github.com/container-storage-interface/spec v1.5.0/go.mod h1:8K96oQNkJ7pFcC2R9Z1ynGGBB1I93kcS6PGg3SsOk8s=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.13+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
@@ -86,8 +86,8 @@ github.com/cucumber/messages-go/v10 v10.0.3/go.mod h1:9jMZ2Y8ZxjLY6TG2+x344nt5rX
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/dell/gocsi v1.4.0 h1:bwR/NMa7RbHr3WO8sLohQ0A8T0Z0h94bVVF2LlMvWRE=
-github.com/dell/gocsi v1.4.0/go.mod h1:bcLfnn4DL8YTYn3RN0JxsYbOpfKjuy3QvC5y1W2mboU=
+github.com/dell/gocsi v1.4.1-0.20211014153731-e18975a3a38c h1:aZb2rtCMt5I8T0eNbJ259NmIOroGavUUsp694d/tcBY=
+github.com/dell/gocsi v1.4.1-0.20211014153731-e18975a3a38c/go.mod h1:nIsIXXB5JpAvOQ0//gtPGULC2+NUddpi5qwpBeMhiLs=
 github.com/dell/gofsutil v1.6.0 h1:u5PiMJIyecAWpSlPloov1/3LF5OWrcjJwoFF8dWkjcA=
 github.com/dell/gofsutil v1.6.0/go.mod h1:98Wpcg7emz4iGgY16fd4MKpnal2SX2hBiwP5ghHlvhg=
 github.com/dell/goisilon v1.5.0 h1:DyIxpc6t74eySvr/WbOIo3QvdcqC+ZhW29e8WVVAYiY=

--- a/helm/csi-isilon/k8s-1.20-values.yaml
+++ b/helm/csi-isilon/k8s-1.20-values.yaml
@@ -8,10 +8,10 @@ images:
 
   # "images.provisioner" defines the container images used for the csi provisioner
   # container.
-  provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+  provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
 
   # "images.snapshotter" defines the container image used for the csi snapshotter
-  snapshotter: k8s.gcr.io/sig-storage/csi-snapshotter:v4.1.1
+  snapshotter: k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.1
 
   # "images.registrar" defines the container images used for the csi registrar
   # container.
@@ -19,5 +19,5 @@ images:
   
   # "images.resizer" defines the container images used for the csi resizer
   # container.
-  resizer: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0 
+  resizer: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0 
 

--- a/helm/csi-isilon/k8s-1.21-values.yaml
+++ b/helm/csi-isilon/k8s-1.21-values.yaml
@@ -8,10 +8,10 @@ images:
 
   # "images.provisioner" defines the container images used for the csi provisioner
   # container.
-  provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+  provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
 
   # "images.snapshotter" defines the container image used for the csi snapshotter
-  snapshotter: k8s.gcr.io/sig-storage/csi-snapshotter:v4.1.1
+  snapshotter: k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.1
 
   # "images.registrar" defines the container images used for the csi registrar
   # container.
@@ -19,5 +19,5 @@ images:
   
   # "images.resizer" defines the container images used for the csi resizer
   # container.
-  resizer: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0 
+  resizer: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
 

--- a/helm/csi-isilon/k8s-1.22-values.yaml
+++ b/helm/csi-isilon/k8s-1.22-values.yaml
@@ -8,10 +8,10 @@ images:
 
   # "images.provisioner" defines the container images used for the csi provisioner
   # container.
-  provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
+  provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
 
   # "images.snapshotter" defines the container image used for the csi snapshotter
-  snapshotter: k8s.gcr.io/sig-storage/csi-snapshotter:v4.1.1
+  snapshotter: k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.1
 
   # "images.registrar" defines the container images used for the csi registrar
   # container.
@@ -19,5 +19,5 @@ images:
 
   # "images.resizer" defines the container images used for the csi resizer
   # container.
-  resizer: k8s.gcr.io/sig-storage/csi-resizer:v1.2.0
+  resizer: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
 

--- a/overrides.mk
+++ b/overrides.mk
@@ -5,7 +5,7 @@
 # DEFAULT values
 # ubi8/ubi-minimal:8.4-208
 DEFAULT_BASEIMAGE="registry.access.redhat.com/ubi8/ubi-minimal@sha256:9ef3aff29b55580c605697f5b8ae662b4b03a390adad86110719a4a2c687cfd1"
-DEFAULT_GOVERSION="1.16.3"
+DEFAULT_GOVERSION="1.16"
 DEFAULT_REGISTRY=""
 DEFAULT_IMAGENAME="isilon"
 DEFAULT_BUILDSTAGE="final"

--- a/service/controller.go
+++ b/service/controller.go
@@ -936,7 +936,9 @@ func (s *service) ControllerPublishVolume(
 		}
 	case csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY:
 		err = isiConfig.isiSvc.AddExportClientNetworkIdentifierByIDWithZone(ctx, exportID, accessZone, nodeID, isiConfig.isiSvc.AddExportReadOnlyClientByIDWithZone)
-	case csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER:
+	case csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER,
+		csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER,
+		csi.VolumeCapability_AccessMode_SINGLE_NODE_MULTI_WRITER:
 		if isROVolumeFromSnapshot {
 			err = fmt.Errorf("unsupported access mode: '%s'", am.String())
 			break
@@ -944,7 +946,7 @@ func (s *service) ControllerPublishVolume(
 		if isiConfig.isiSvc.OtherClientsAlreadyAdded(ctx, exportID, accessZone, nodeID) {
 			return nil, status.Errorf(codes.FailedPrecondition, utils.GetMessageWithRunID(runID,
 				"export '%d' in access zone '%s' already has other clients added to it, and the access mode is "+
-					"SINGLE_NODE_WRITER, thus the request fails", exportID, accessZone))
+					"%s, thus the request fails", exportID, accessZone, am.Mode))
 		}
 
 		if !isiConfig.isiSvc.IsHostAlreadyAdded(ctx, exportID, accessZone, utils.DummyHostNodeID) {
@@ -1271,6 +1273,13 @@ func (s *service) ControllerGetCapabilities(
 					},
 				},
 			},
+			{
+				Type: &csi.ControllerServiceCapability_Rpc{
+					Rpc: &csi.ControllerServiceCapability_RPC{
+						Type: csi.ControllerServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
+					},
+				},
+			},
 		},
 	}, nil
 }
@@ -1593,6 +1602,10 @@ func validateVolumeCaps(
 			supported = false
 			reason = errUnknownAccessMode
 		case csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER:
+			break
+		case csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER:
+			break
+		case csi.VolumeCapability_AccessMode_SINGLE_NODE_MULTI_WRITER:
 			break
 		case csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY:
 			supported = false

--- a/service/features/node_publish_unpublish.feature
+++ b/service/features/node_publish_unpublish.feature
@@ -18,12 +18,39 @@ Feature: Isilon CSI interface
     | voltype      | access                         |  errormsg                                    |
     | "mount"      | "single-writer"                | "none"                                       |
     | "mount"      | "multiple-writer"              | "none"                                       |
+    | "mount"      | "single-node-single-writer"    | "none"                                       |
+    | "mount"      | "single-node-multiple-writer"     | "none"                                       |
 
   Scenario Outline: Node publish mount volumes various induced error use cases from examples
     Given a Isilon service
     And I have a Node "node1" with AccessZone
     And a controller published volume
     And a capability with voltype "mount" access "single-writer"
+    And get Node Publish Volume Request
+    And I induce error <errora>
+    When I call Probe
+    When I call NodePublishVolume
+    Then the error contains <errormsg>
+
+    Examples:
+    | errora                                  | errormsg                                                                  |
+    | "GOFSMockDevMountsError"                | "none"                                                                    |
+    | "GOFSMockMountError"                    | "mode conflicts with existing mounts@@mount induced error"                |
+    | "GOFSMockGetMountsError"                | "could not reliably determine existing mount status"                      |
+    # may be different for Windows vs. Linux
+    | "TargetNotCreatedForNodePublish"        | "none"                                                                    |
+    | "NodePublishNoTargetPath"               | "Target Path is required"                                                 |
+    | "NodePublishNoVolumeCapability"         | "Volume Capability is required"                                           |
+    | "NodePublishNoAccessMode"               | "Volume Access Mode is required"                                          |
+    | "NodePublishNoAccessType"               | "Invalid access type"                                                     |
+    | "NodePublishFileTargetNotDir"           | "existing path is not a directory"                                        |
+    | "VolInstanceError"                      | "Error retrieving Volume"                                                 |
+
+  Scenario Outline: Node publish mount volumes various induced error use cases from examples
+    Given a Isilon service
+    And I have a Node "node1" with AccessZone
+    And a controller published volume
+    And a capability with voltype "mount" access "single-node-single-writer"
     And get Node Publish Volume Request
     And I induce error <errora>
     When I call Probe
@@ -59,10 +86,14 @@ Feature: Isilon CSI interface
     | voltype      | access                         | errormsg                                             |
     | "mount"      | "multiple-reader"              | "none"                                               |
     | "mount"      | "single-writer"                | "Mount point already in use for same device"         |
+    | "mount"      | "single-node-single-writer"    | "Mount point already in use for same device"         |
     | "mount"      | "multiple-writer"              | "none"                                               |
+    | "mount"      | "single-node-multiple-writer"  | "none"                                               |
     | "block"      | "single-writer"                | "Invalid access type"                                |
     | "block"      | "multiple-writer"              | "Invalid access type"                                |
     | "block"      | "multiple-reader"              | "Invalid access type"                                |
+    | "block"      | "single-node-single-writer"    | "Invalid access type"                                |
+    | "block"      | "single-node-multiple-writer"  | "Invalid access type"                                |
 
   Scenario Outline: Node publish various use cases from examples when read-only mount volume already published (T1!=T2, P1==P2)
     Given a Isilon service
@@ -103,7 +134,9 @@ Feature: Isilon CSI interface
     | "mount"      | "single-reader"                | "Mount point already in use for same device" |
     | "mount"      | "multiple-reader"              | "none"                                       |
     | "mount"      | "single-writer"                | "Mount point already in use for same device" |
+    | "mount"      | "single-node-single-writer"    | "Mount point already in use for same device" |
     | "mount"      | "multiple-writer"              | "none"                                       |
+    | "mount"      | "single-node-multiple-writer"  | "none"                                       |
     | "block"      | "multiple-reader"              | "Invalid access type"                        |
 
   Scenario Outline: Node publish various use cases from examples when already published volume changed to read-only with same target(T1==T2, P1!=P2)
@@ -123,6 +156,8 @@ Feature: Isilon CSI interface
     | "mount"      | "single-reader"                | "Mount point already in use by device with different options"                                        |
     | "mount"      | "multiple-reader"              | "Mount point already in use by device with different options"                                        |
     | "mount"      | "single-writer"                | "Mount point already in use by device with different options"                                        |
+    | "mount"      | "single-node-single-writer"    | "Mount point already in use by device with different options"                                        |
+    | "mount"      | "single-node-multiple-writer"  | "Mount point already in use by device with different options"                                        |
     | "mount"      | "multiple-writer"              | "Mount point already in use by device with different options"                                        |
     | "block"      | "multiple-reader"              | "Invalid access type"                                                                                |
 
@@ -142,6 +177,8 @@ Feature: Isilon CSI interface
     | "mount"      | "single-reader"                | "none"                                       |
     | "mount"      | "multiple-reader"              | "none"                                       |
     | "mount"      | "single-writer"                | "none" |
+    | "mount"      | "single-node-single-writer"                | "none" |
+    | "mount"      | "single-node-multiple-writer"              | "none" |
     | "mount"      | "multiple-writer"              | "none"                                       |
     | "block"      | "multiple-reader"              | "Invalid access type"                        |
 

--- a/service/features/service.feature
+++ b/service/features/service.feature
@@ -46,6 +46,8 @@ Feature: Isilon CSI interface
       Examples:
       | voltype    | access                     | errormsg                                                   |
       | "mount"    | "single-writer"            | "none"                                                     |
+      | "mount"    | "single-node-single-writer"   | "none"                                                     |
+      | "mount"    | "single-node-multiple-writer" | "none"                                                     |
       | "mount"    | "single-reader"            | "Single node only reader access mode is not supported"     |
       | "mount"    | "multi-reader"             | "none"                                                     |
       | "mount"    | "multi-writer"             | "none"                                                     |

--- a/service/mount.go
+++ b/service/mount.go
@@ -109,11 +109,11 @@ func publishVolume(
 				}
 				//T1!=T2, P1==P2 || P1 != P2 - return FailedPrecondition for single node
 				if accMode.GetMode() == csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER ||
-					accMode.GetMode() == csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY {
+					accMode.GetMode() == csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY ||
+					accMode.GetMode() == csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER {
 					logrus.WithFields(f).Error("Mount point already in use for same device")
 					return status.Error(codes.FailedPrecondition, "Mount point already in use for same device")
 				}
-
 			}
 		}
 	}

--- a/service/node.go
+++ b/service/node.go
@@ -281,6 +281,13 @@ func (s *service) NodeGetCapabilities(
 					},
 				},
 			},
+			{
+				Type: &csi.NodeServiceCapability_Rpc{
+					Rpc: &csi.NodeServiceCapability_RPC{
+						Type: csi.NodeServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER,
+					},
+				},
+			},
 			/*{
 				Type: &csi.NodeServiceCapability_Rpc{
 					Rpc: &csi.NodeServiceCapability_RPC{

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -226,7 +226,7 @@ func (f *feature) getService() *service {
 	svc.mode = "controller"
 	f.service = svc
 	f.service.nodeID, _ = os.Hostname()
-	f.service.nodeIP = "1.2.3.4"
+	f.service.nodeIP = "127.0.0.1"
 	f.service.defaultIsiClusterName = clusterName1
 	f.service.isiClusters = new(sync.Map)
 	f.service.isiClusters.Store(newConfig.ClusterName, &newConfig)
@@ -809,11 +809,13 @@ func (f *feature) aValidControllerGetCapabilitiesResponseIsReturned() error {
 				count = count + 1
 			case csi.ControllerServiceCapability_RPC_EXPAND_VOLUME:
 				count = count + 1
+			case csi.ControllerServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER:
+				count = count + 1
 			default:
 				return fmt.Errorf("received unexpected capability: %v", rpcType)
 			}
 		}
-		if count != 7 /*7*/ {
+		if count != 8 /*7*/ {
 			return errors.New("Did not retrieve all the expected capabilities")
 		}
 		return nil
@@ -854,6 +856,10 @@ func (f *feature) iCallValidateVolumeCapabilitiesWithVoltypeAccess(voltype, acce
 		accessMode.Mode = csi.VolumeCapability_AccessMode_MULTI_NODE_READER_ONLY
 	case "multi-node-single-writer":
 		accessMode.Mode = csi.VolumeCapability_AccessMode_MULTI_NODE_SINGLE_WRITER
+	case "single-node-single-writer":
+		accessMode.Mode = csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER
+	case "single-node-multiple-writer":
+		accessMode.Mode = csi.VolumeCapability_AccessMode_SINGLE_NODE_MULTI_WRITER
 	}
 	capability.AccessMode = accessMode
 	capabilities := make([]*csi.VolumeCapability, 0)
@@ -1067,11 +1073,13 @@ func (f *feature) aValidNodeGetCapabilitiesResponseIsReturned() error {
 				count = count + 1
 			case csi.NodeServiceCapability_RPC_EXPAND_VOLUME:
 				count = count + 1
+			case csi.NodeServiceCapability_RPC_SINGLE_NODE_MULTI_WRITER:
+				count = count + 1
 			default:
 				return fmt.Errorf("Received unexpected capability: %v", rpcType)
 			}
 		}
-		if count != 1 /*3*/ {
+		if count != 2 /*3*/ {
 			return errors.New("Did not retrieve all the expected capabilities")
 		}
 		return nil
@@ -1331,6 +1339,10 @@ func (f *feature) aCapabilityWithVoltypeAccess(voltype, access string) error {
 		accessMode.Mode = csi.VolumeCapability_AccessMode_SINGLE_NODE_READER_ONLY
 	case "single-writer":
 		accessMode.Mode = csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
+	case "single-node-single-writer":
+		accessMode.Mode = csi.VolumeCapability_AccessMode_SINGLE_NODE_SINGLE_WRITER
+	case "single-node-multiple-writer":
+		accessMode.Mode = csi.VolumeCapability_AccessMode_SINGLE_NODE_MULTI_WRITER
 	case "multiple-writer":
 		accessMode.Mode = csi.VolumeCapability_AccessMode_MULTI_NODE_MULTI_WRITER
 	case "multiple-reader":
@@ -2012,7 +2024,7 @@ func (f *feature) getServiceWithParamsForCustomTopology(user, mode string, apply
 	f.service = svc
 	f.service.nodeID = host
 	// TODO - IP has to be updated before release
-	f.service.nodeIP = "1.2.3.4"
+	f.service.nodeIP = "127.0.0.1"
 	f.service.defaultIsiClusterName = clusterName1
 	f.service.isiClusters = new(sync.Map)
 	f.service.isiClusters.Store(newConfig.ClusterName, &newConfig)
@@ -2051,7 +2063,7 @@ func (f *feature) getServiceWithParams(user, mode string) *service {
 	svc.mode = mode
 	f.service = svc
 	f.service.nodeID, _ = os.Hostname()
-	f.service.nodeIP = "1.2.3.4"
+	f.service.nodeIP = "127.0.0.1"
 	f.service.defaultIsiClusterName = clusterName1
 	f.service.isiClusters = new(sync.Map)
 	f.service.isiClusters.Store(newConfig.ClusterName, &newConfig)


### PR DESCRIPTION
# Description

1. Added support for SINGLE_NODE_SINGLE_WRITER and SINGLE_NODE_MULTI_WRITER in csi-powerscale driver.
2. Also added csi spec v1.5 support

# GitHub Issues
https://github.com/dell/csm/issues/80


# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?

1. Added unit tests
2. Verified new access modes on k8s 1.22, by creating PVC with access mode ReadWriteOnce and ReadWriteOncePod
3. Made sure there is no regression as a result of new changes. Created PVC with access mode ReadWriteOnce on k8s 1.21 and confirmed that it can be attached to a single pod at any time on a single node(Existing functionality).
