### PR TITLE
CSI-Powerscale 2.2 changes

### DIFF
--- a/Dockerfile.podman
+++ b/Dockerfile.podman
@@ -52,7 +52,7 @@ LABEL vendor="Dell Inc." \
       name="csi-isilon" \
       summary="CSI Driver for Dell EMC PowerScale" \
       description="CSI Driver for provisioning persistent storage from Dell EMC PowerScale" \
-      version="2.1.0" \
+      version="2.2.0" \
       license="Apache-2.0"
 
 COPY ./licenses /licenses

--- a/dell-csi-helm-installer/verify-csi-isilon.sh
+++ b/dell-csi-helm-installer/verify-csi-isilon.sh
@@ -11,7 +11,7 @@
 #
 # verify-csi-isilon method
 function verify-csi-isilon() {
-  verify_k8s_versions "1.20" "1.22"
+  verify_k8s_versions "1.21" "1.23"
   verify_openshift_versions "4.8" "4.9"
   verify_namespace "${NS}"
   verify_required_secrets "${RELEASE}-creds"
@@ -19,6 +19,6 @@ function verify-csi-isilon() {
   verify_alpha_snap_resources
   verify_snap_requirements
   verify_helm_3
-  verify_helm_values_version "2.1.0"
+  verify_helm_values_version "2.2.0"
   verify_authorization_proxy_server
 }

--- a/helm/csi-isilon/Chart.yaml
+++ b/helm/csi-isilon/Chart.yaml
@@ -1,6 +1,6 @@
 name: csi-isilon
-version: 2.1.0
-appVersion: 2.1.0
+version: 2.2.0
+appVersion: 2.2.0
 description: |
   PowerScale CSI (Container Storage Interface) driver Kubernetes
   integration. This chart includes everything required to provision via CSI as

--- a/helm/csi-isilon/driver-image.yaml
+++ b/helm/csi-isilon/driver-image.yaml
@@ -1,4 +1,4 @@
 # IT IS RECOMMENDED YOU DO NOT CHANGE THE IMAGES TO BE DOWNLOADED.
 images:
   # "images.driver" defines the container images used for the driver container.
-  driver: dellemc/csi-isilon:v2.1.0
+  driver: dellemc/csi-isilon:v2.2.0

--- a/helm/csi-isilon/k8s-1.21-values.yaml
+++ b/helm/csi-isilon/k8s-1.21-values.yaml
@@ -15,7 +15,7 @@ images:
 
   # "images.registrar" defines the container images used for the csi registrar
   # container.
-  registrar: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
+  registrar: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
   
   # "images.resizer" defines the container images used for the csi resizer
   # container.

--- a/helm/csi-isilon/k8s-1.22-values.yaml
+++ b/helm/csi-isilon/k8s-1.22-values.yaml
@@ -15,7 +15,7 @@ images:
 
   # "images.registrar" defines the container images used for the csi registrar
   # container.
-  registrar: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
+  registrar: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
 
   # "images.resizer" defines the container images used for the csi resizer
   # container.

--- a/helm/csi-isilon/k8s-1.23-values.yaml
+++ b/helm/csi-isilon/k8s-1.23-values.yaml
@@ -1,4 +1,4 @@
-kubeversion: "v1.20"
+kubeversion: "v1.23"
 
 # IT IS RECOMMENDED YOU DO NOT CHANGE THE IMAGES TO BE DOWNLOADED.
 images:
@@ -15,7 +15,7 @@ images:
 
   # "images.registrar" defines the container images used for the csi registrar
   # container.
-  registrar: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
+  registrar: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
   
   # "images.resizer" defines the container images used for the csi resizer
   # container.

--- a/helm/csi-isilon/templates/csidriver.yaml
+++ b/helm/csi-isilon/templates/csidriver.yaml
@@ -1,8 +1,4 @@
-{{- if or (eq .Capabilities.KubeVersion.Minor "17") (eq .Capabilities.KubeVersion.Minor "17+")}}
-apiVersion: storage.k8s.io/v1beta1
-{{- else }}
 apiVersion: storage.k8s.io/v1
-{{- end }}
 kind: CSIDriver
 metadata:
     name: csi-isilon.dellemc.com

--- a/helm/csi-isilon/values.yaml
+++ b/helm/csi-isilon/values.yaml
@@ -2,7 +2,7 @@
 ########################
 # version: version of this values file
 # Note: Do not change this value
-version: "2.1.0"
+version: "2.2.0"
 
 # CSI driver log level
 # Allowed values: "error", "warn"/"warning", "info", "debug"


### PR DESCRIPTION
# Description
Updated PowerScale version to 2.2
Added k8s 1.23 support and removed k8s 1.20

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/128 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Performed sanity on cert-csi in k8s cluster
- [x] Ran unit-tests
