### PR TITLE
Remove reverseDNS lookup mandate for nodeID

### DIFF
--- a/service/features/service.feature
+++ b/service/features/service.feature
@@ -127,6 +127,11 @@ Feature: Isilon CSI interface
       Then a valid NodeGetInfoResponse is returned with volume limit "2"
       And I call remove node labels
 
+    Scenario: Call NodeGetInfo When reverse DNS is absent
+      Given a Isilon service
+      When I call iCallNodeGetInfoWithNoFQDN
+      Then a valid NodeGetInfoResponse is returned
+
     Scenario: Call NodeGetCapabilities with health monitor feature enabled
       Given a Isilon service
       When I call NodeGetCapabilities "true"

--- a/service/node.go
+++ b/service/node.go
@@ -725,7 +725,8 @@ func (s *service) getPowerScaleNodeID(ctx context.Context) (string, error) {
 
 	nodeFQDN, err := utils.GetFQDNByIP(ctx, nodeIP)
 	if (err) != nil {
-		return "", err
+		nodeFQDN = nodeIP
+		log.Warnf("Setting nodeFQDN to %s as failed to resolve IP to FQDN due to %v", nodeIP, err)
 	}
 
 	nodeID, err := s.GetCSINodeID(ctx)

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -335,6 +335,8 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^I call ControllerGetVolume with name "([^"]*)"$`, f.iCallControllerGetVolume)
 	s.Step(`^a valid ControllerGetVolumeResponse is returned$`, f.aValidControllerGetVolumeResponseIsReturned)
 	s.Step(`^I call NodeGetVolumeStats with name "([^"]*)" and path "([^"]*)"$`, f.iCallNodeGetVolumeStats)
+	s.Step(`^I call iCallNodeGetInfoWithNoFQDN`, f.iCallNodeGetInfoWithNoFQDN)
+	s.Step(`^a valid NodeGetInfoResponse is returned$`, f.aValidNodeGetInfoResponseIsReturned)
 }
 
 // GetPluginInfo
@@ -2217,5 +2219,16 @@ func (f *feature) iCallNodeGetInfowithinvalidnetworks() error {
 }
 func (f *feature) iSetRootClientEnabledTo(val string) error {
 	f.rootClientEnabled = val
+	return nil
+}
+
+func (f *feature) iCallNodeGetInfoWithNoFQDN() error {
+	req := new(csi.NodeGetInfoRequest)
+	f.service.nodeIP = "192.0.2.0"
+	f.nodeGetInfoResponse, f.err = f.service.NodeGetInfo(context.Background(), req)
+	if f.err != nil {
+		log.Printf("NodeGetInfo call failed: %s\n", f.err.Error())
+		return f.err
+	}
 	return nil
 }

--- a/test/integration/features/main_integration.feature
+++ b/test/integration/features/main_integration.feature
@@ -558,6 +558,20 @@ Feature: Isilon CSI interface
     | 4               |
 
   @v1.0
+  Scenario: Create, ControllerPublish, ControllerUnpublish, delete basic volume , run with nodeID which has IP isntead of FQDN
+    Given a Isilon service
+    And a basic volume request "integration0" "8"
+    When I call CreateVolume
+    When I call ControllerPublishVolume "X_CSI_NODE_NAME_NO_FQDN"
+    Then there are no errors
+    When I call ControllerUnpublishVolume "X_CSI_NODE_NAME_NO_FQDN"
+    Then there are no errors
+    When I call DeleteVolume
+    Then there is not a directory "integration0"
+    Then there is not an export "integration0"
+
+
+  @v1.0
     Scenario: Cleanup all the files created
       Given a Isilon service
       When I call DeleteAllVolumes

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -60,7 +60,7 @@ func TestMain(m *testing.M) {
 		nodeName := host + nodeIDSeparator + hostFQDN + nodeIDSeparator + nodeIP
 		os.Setenv("X_CSI_NODE_NAME", nodeName)
 	}
-	nodeNameWithoutFQDN  := host + nodeIDSeparator + nodeIP + nodeIDSeparator + nodeIP
+	nodeNameWithoutFQDN := host + nodeIDSeparator + nodeIP + nodeIDSeparator + nodeIP
 	os.Setenv("X_CSI_NODE_NAME_NO_FQDN", nodeNameWithoutFQDN)
 
 	// Make the file needed for NodeStage:

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -55,10 +55,13 @@ func TestMain(m *testing.M) {
 	if hostFQDN == "unknown" {
 		fmt.Printf("cannot get FQDN")
 	}
+	nodeIP := os.Getenv("X_CSI_NODE_IP")
 	if os.Getenv("X_CSI_CUSTOM_TOPOLOGY_ENABLED") == "true" {
-		nodeName := host + nodeIDSeparator + hostFQDN + nodeIDSeparator + os.Getenv("X_CSI_NODE_IP")
+		nodeName := host + nodeIDSeparator + hostFQDN + nodeIDSeparator + nodeIP
 		os.Setenv("X_CSI_NODE_NAME", nodeName)
 	}
+	nodeNameWithoutFQDN  := host + nodeIDSeparator + nodeIP + nodeIDSeparator + nodeIP
+	os.Setenv("X_CSI_NODE_NAME_NO_FQDN", nodeNameWithoutFQDN)
 
 	// Make the file needed for NodeStage:
 	//  /tmp/datadir    -- for file system mounts


### PR DESCRIPTION
# Description
CSI-PowerScale driver crashes when resolution of IP to FQDN fails , this is on environments where we don't have a reverse lookup IP record.
We could choose between nodename and IP. Have considered IP when IP resolution to FQDN fails.

# GitHub Issues
https://github.com/dell/csm/issues/142

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Installed CSI-PowerScale with main branch changes and was able to create and delete storage class, PVC and pods.
- [x] Installed CSI-PowerScale driver with 2.1.0 version and create storage class, PVC and pods. Changed to main branch with the changes, installed the main branch build image and deleted the existing storage class, PVC and pods, which were successful.
