### PR TITLE
KRV-2731 : Verification of secrets repeated twice while installation of driver via helm 

### DIFF
--- a/dell-csi-helm-installer/csi-install.sh
+++ b/dell-csi-helm-installer/csi-install.sh
@@ -15,7 +15,7 @@ PROG="${0}"
 NODE_VERIFY=1
 VERIFY=1
 MODE="install"
-DEFAULT_DRIVER_VERSION="2.0.0"
+DEFAULT_DRIVER_VERSION="2.2.0"
 WATCHLIST=""
 
 # export the name of the debug log, so child processes will see it

--- a/dell-csi-helm-installer/verify.sh
+++ b/dell-csi-helm-installer/verify.sh
@@ -147,7 +147,12 @@ function verify_fc_installation() {
 
 # verify secrets exist
 function verify_required_secrets() {
-  log step "Verifying that required secrets have been created"
+  if [[ "${@}" == *"-certs"* ]]; then
+    log step "Verifying that required secrets for certs have been created"
+  fi
+  if [[ "${@}" == *"-creds"* ]]; then
+      log step "Verifying that required secrets for creds have been created"
+  fi
 
   error=0
   for N in "${@}"; do


### PR DESCRIPTION
# Description
Verification of secrets repeated twice while installation of driver via helm 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/168 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
<img width="403" alt="2" src="https://user-images.githubusercontent.com/92289639/151778045-5022b172-4279-4c07-b8b0-fd43a2a6607f.PNG">

