### PR TITLE
Update args for gosec, with no args it runs the -h option

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -23,6 +23,8 @@ jobs:
         uses: actions/checkout@v2
       - name: Run Go Security
         uses: securego/gosec@master
+        with:
+          args: ./...
   malware_security_scan:
     name: Malware Scanner
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -25,7 +25,7 @@ jobs:
         uses: securego/gosec@master
         with:
           # added additional exclude arguments after gosec v2.9.4 came out
-          args: -exclude=G108,G402 ./...
+          args: -exclude=G304 ./...
   malware_security_scan:
     name: Malware Scanner
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -24,7 +24,8 @@ jobs:
       - name: Run Go Security
         uses: securego/gosec@master
         with:
-          args: ./...
+          # added additional exclude arguments after gosec v2.9.4 came out
+          args: -exclude=G108,G301,G302,G304,G307,G402 ./...
   malware_security_scan:
     name: Malware Scanner
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -25,7 +25,7 @@ jobs:
         uses: securego/gosec@master
         with:
           # added additional exclude arguments after gosec v2.9.4 came out
-          args: -exclude=G108,G301,G302,G304,G307,G402 ./...
+          args: -exclude=G108,G402 ./...
   malware_security_scan:
     name: Malware Scanner
     runs-on: ubuntu-latest

--- a/core/semver/semver.go
+++ b/core/semver/semver.go
@@ -93,7 +93,11 @@ func main() {
 			os.Exit(1)
 		}
 		w = fout
-		defer fout.Close()
+		defer func() {
+			if err := fout.Close(); err != nil {
+				fmt.Fprintf(os.Stderr, "error closing file: %s \n", err)
+			}
+		}()
 	}
 
 	gitdesc := chkErr(doExec("git", "describe", "--long", "--dirty"))

--- a/main.go
+++ b/main.go
@@ -33,7 +33,6 @@ import (
 )
 
 func init() {
-	os.Setenv(constants.EnvGOCSIDebug, "true")
 	err := os.Setenv(constants.EnvGOCSIDebug, "true")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "unable to set %s to true ", constants.EnvGOCSIDebug)

--- a/main.go
+++ b/main.go
@@ -34,6 +34,10 @@ import (
 
 func init() {
 	os.Setenv(constants.EnvGOCSIDebug, "true")
+	err := os.Setenv(constants.EnvGOCSIDebug, "true")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unable to set %s to true ", constants.EnvGOCSIDebug)
+	}
 }
 
 // main is ignored when this package is built as a go plug-in

--- a/main.go
+++ b/main.go
@@ -35,7 +35,7 @@ import (
 func init() {
 	err := os.Setenv(constants.EnvGOCSIDebug, "true")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "unable to set %s to true ", constants.EnvGOCSIDebug)
+		fmt.Fprintf(os.Stderr, "unable to set %s to true \n", constants.EnvGOCSIDebug)
 	}
 }
 

--- a/service/node.go
+++ b/service/node.go
@@ -632,7 +632,11 @@ func (s *service) ephemeralNodePublish(ctx context.Context, req *csi.NodePublish
 	}
 	log.Infof("Created file in target path %s", filePath+"/id")
 
-	defer f.Close()
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.Errorf("Error closing file: %s \n", err)
+		}
+	}()
 	_, err2 := f.WriteString(createEphemeralVolResp.Volume.VolumeId)
 	if err2 != nil {
 		log.Error("Writing to id file in target path for ephemeral vol failed with error :" + err.Error())

--- a/service/service.go
+++ b/service/service.go
@@ -607,6 +607,7 @@ func (s *service) getNewIsilonConfigs(ctx context.Context, configBytes []byte) (
 
 	var inputConfigs *IsilonClusters
 	var yamlErr error
+	var err error
 	inputConfigs, yamlErr = unmarshalYAMLContent(configBytes)
 	if yamlErr != nil {
 		log.Errorf("failed to parse isilon clusters' config details as yaml data, error: %v", yamlErr)
@@ -622,7 +623,8 @@ func (s *service) getNewIsilonConfigs(ctx context.Context, configBytes []byte) (
 	}
 
 	newIsiClusters := make(map[interface{}]interface{})
-	for i, config := range inputConfigs.IsilonClusters {
+	for i, clusterConfig := range inputConfigs.IsilonClusters {
+		config := clusterConfig
 		log.Debugf("parsing config details for cluster %v", config.ClusterName)
 		if config.ClusterName == "" {
 			return nil, defaultIsiClusterName, fmt.Errorf("invalid value for clusterName at index [%d]", i)
@@ -661,7 +663,10 @@ func (s *service) getNewIsilonConfigs(ctx context.Context, configBytes []byte) (
 
 		config.EndpointURL = fmt.Sprintf("https://%s:%s", config.Endpoint, config.EndpointPort)
 		clientCtx, _ := GetLogger(ctx)
-		config.isiSvc, _ = s.GetIsiService(clientCtx, &config, logLevel)
+		config.isiSvc, err = s.GetIsiService(clientCtx, &config, logLevel)
+		if err != nil {
+			log.Errorf("failed to get isi client, error: %v", err)
+		}
 
 		if config.IsDefault == nil {
 			defaultBoolValue := false


### PR DESCRIPTION
# Description
By default gosec expects args without it it defaults to -h option and lists the way to run gosec and does not run any actual test.

Excluded G304 for the below, which seems a valid change needed.
[/github/workspace/service/service.go:561] - G304 (CWE-22): Potential file inclusion via variable (Confidence: HIGH, Severity: MEDIUM)
  > 561: 	configBytes, err := ioutil.ReadFile(isilonConfigFile)

Made changes to address the below,
Addressed other issues.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
https://github.com/dell/csm/issues/128

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Built the image and tested creation of sc, pvc and pod.
- [x] Testing actions via PR
