### PR TITLE
Disable all probes to array when noProbeOnStart is set to true

### DIFF
--- a/helm/csi-isilon/values.yaml
+++ b/helm/csi-isilon/values.yaml
@@ -282,6 +282,7 @@ isiPath: /ifs/data/csi
 isiVolumePathPermissions: "0777"
 
 # noProbeOnStart: Indicates whether the controller/node should probe all the PowerScale clusters during driver initialization
+# When set to true, the driver will not set node labels, please specify label <provisionerName>.dellemc.com/<powerscalefqdnorip>:<provisionerName>
 # Allowed values:
 #   true : do not probe all PowerScale clusters during driver initialization
 #   false: probe all PowerScale clusters during driver initialization

--- a/helm/csi-isilon/values.yaml
+++ b/helm/csi-isilon/values.yaml
@@ -282,7 +282,7 @@ isiPath: /ifs/data/csi
 isiVolumePathPermissions: "0777"
 
 # noProbeOnStart: Indicates whether the controller/node should probe all the PowerScale clusters during driver initialization
-# When set to true, the driver will not set node labels, please manually add 
+# When set to true, the driver will not set node labels, please manually add
 # the label <provisionerName>.dellemc.com/<powerscalefqdnorip>:<provisionerName> on the nodes for each of the clusters reachable from the node.
 # Allowed values:
 #   true : do not probe all PowerScale clusters during driver initialization

--- a/helm/csi-isilon/values.yaml
+++ b/helm/csi-isilon/values.yaml
@@ -282,7 +282,8 @@ isiPath: /ifs/data/csi
 isiVolumePathPermissions: "0777"
 
 # noProbeOnStart: Indicates whether the controller/node should probe all the PowerScale clusters during driver initialization
-# When set to true, the driver will not set node labels, please specify label <provisionerName>.dellemc.com/<powerscalefqdnorip>:<provisionerName>
+# When set to true, the driver will not set node labels.
+# Please manually add the label <provisionerName>.dellemc.com/<powerscalefqdnorip>:<provisionerName> on the nodes for each of the clusters reachable from the node.
 # Allowed values:
 #   true : do not probe all PowerScale clusters during driver initialization
 #   false: probe all PowerScale clusters during driver initialization

--- a/helm/csi-isilon/values.yaml
+++ b/helm/csi-isilon/values.yaml
@@ -282,8 +282,8 @@ isiPath: /ifs/data/csi
 isiVolumePathPermissions: "0777"
 
 # noProbeOnStart: Indicates whether the controller/node should probe all the PowerScale clusters during driver initialization
-# When set to true, the driver will not set node labels.
-# Please manually add the label <provisionerName>.dellemc.com/<powerscalefqdnorip>:<provisionerName> on the nodes for each of the clusters reachable from the node.
+# When set to true, the driver will not set node labels, please manually add 
+# the label <provisionerName>.dellemc.com/<powerscalefqdnorip>:<provisionerName> on the nodes for each of the clusters reachable from the node.
 # Allowed values:
 #   true : do not probe all PowerScale clusters during driver initialization
 #   false: probe all PowerScale clusters during driver initialization

--- a/service/controller.go
+++ b/service/controller.go
@@ -975,6 +975,8 @@ func (s *service) ControllerPublishVolume(
 
 	// Fetch log handler
 	ctx, log, runID := GetRunIDLog(ctx)
+	//set noProbeOnStart to false so subsequent calls can lead to probe
+	noProbeOnStart = false
 
 	volumeContext := req.GetVolumeContext()
 	if volumeContext != nil {
@@ -1265,6 +1267,8 @@ func (s *service) ControllerUnpublishVolume(
 
 	// Fetch log handler
 	ctx, log, runID := GetRunIDLog(ctx)
+	//set noProbeOnStart to false so subsequent calls can lead to probe
+	noProbeOnStart = false
 
 	if req.VolumeId == "" {
 		return nil, status.Errorf(codes.InvalidArgument, utils.GetMessageWithRunID(runID, "ControllerUnpublishVolumeRequest.VolumeId is empty"))

--- a/service/controller.go
+++ b/service/controller.go
@@ -178,6 +178,8 @@ func (s *service) CreateVolume(
 
 	// Fetch log handler
 	ctx, log, runID := GetRunIDLog(ctx)
+	//set noProbeOnStart to false so subsequent calls can lead to probe
+	noProbeOnStart = false
 
 	isiConfig, err := s.getIsilonConfig(ctx, &clusterName)
 	if err != nil {
@@ -714,6 +716,8 @@ func (s *service) DeleteVolume(
 	// TODO more checks need to be done, e.g. if access mode is VolumeCapability_AccessMode_MULTI_NODE_XXX, then other nodes might still be using this volume, thus the delete should be skipped
 	// Fetch log handler
 	ctx, log, _ := GetRunIDLog(ctx)
+	//set noProbeOnStart to false so subsequent calls can lead to probe
+	noProbeOnStart = false
 
 	// validate request
 	if err := s.ValidateDeleteVolumeRequest(ctx, req); err != nil {
@@ -1292,8 +1296,8 @@ func (s *service) ControllerUnpublishVolume(
 	}
 
 	if err := isiConfig.isiSvc.RemoveExportClientByIDWithZone(ctx, exportID, accessZone, nodeID); err != nil {
-		return nil, status.Errorf(codes.Internal, utils.GetMessageWithRunID(runID, "error encountered when"+
-			" trying to remove client '%s' from export '%d' with access zone '%s' on cluster '%s'", nodeID, exportID, accessZone, clusterName))
+		return nil, status.Errorf(codes.Internal, utils.GetMessageWithRunID(runID, "error %s encountered when"+
+			" trying to remove client '%s' from export '%d' with access zone '%s' on cluster '%s'", err, nodeID, exportID, accessZone, clusterName))
 	}
 
 	return &csi.ControllerUnpublishVolumeResponse{}, nil

--- a/service/identity.go
+++ b/service/identity.go
@@ -87,7 +87,7 @@ func (s *service) Probe(
 	rep.Ready = ready
 
 	if noProbeOnStart {
-		log.Debugf("set noProbeOnStart to true and skip probe")
+		log.Debugf("noProbeOnStart is set to true, skip probe")
 		return rep, nil
 	}
 

--- a/service/identity.go
+++ b/service/identity.go
@@ -19,9 +19,9 @@ package service
 import (
 	"fmt"
 	csiext "github.com/dell/dell-csi-extensions/replication"
-	"strings"
 
 	"golang.org/x/net/context"
+	"strings"
 
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	wrappers "github.com/golang/protobuf/ptypes/wrappers"
@@ -85,6 +85,11 @@ func (s *service) Probe(
 	ready.Value = true
 	rep := new(csi.ProbeResponse)
 	rep.Ready = ready
+
+	if noProbeOnStart {
+		log.Debugf("set noProbeOnStart to true and skip probe")
+		return rep, nil
+	}
 
 	if err := s.probeAllClusters(ctx); err != nil {
 		rep.Ready.Value = false

--- a/service/node.go
+++ b/service/node.go
@@ -351,7 +351,7 @@ func (s *service) NodeGetInfo(
 		return nil, err
 	}
 	if noProbeOnStart {
-		log.Debugf("set noProbeOnStart to true and skip probe")
+		log.Debugf("noProbeOnStart is set to true, skip probe")
 		return &csi.NodeGetInfoResponse{NodeId: nodeID}, nil
 	}
 	// If Custom Topology is enabled we do not add node labels to the worker node

--- a/service/node.go
+++ b/service/node.go
@@ -72,6 +72,8 @@ func (s *service) NodePublishVolume(
 
 	// Fetch log handler
 	ctx, log, runID := GetRunIDLog(ctx)
+	//set noProbeOnStart to false so subsequent calls can lead to probe
+	noProbeOnStart = false
 
 	volumeContext := req.GetVolumeContext()
 	if volumeContext == nil {
@@ -168,6 +170,8 @@ func (s *service) NodeUnpublishVolume(
 	ctx, log, runID := GetRunIDLog(ctx)
 
 	log.Debug("executing NodeUnpublishVolume")
+	//set noProbeOnStart to false so subsequent calls can lead to probe
+	noProbeOnStart = false
 	volID := req.GetVolumeId()
 	if volID == "" {
 		return nil, status.Error(codes.FailedPrecondition, utils.GetMessageWithRunID(runID, "no VolumeID found in request"))
@@ -346,7 +350,10 @@ func (s *service) NodeGetInfo(
 		log.Error("Failed to create Node ID with error", err.Error())
 		return nil, err
 	}
-
+	if noProbeOnStart {
+		log.Debugf("set noProbeOnStart to true and skip probe")
+		return &csi.NodeGetInfoResponse{NodeId: nodeID}, nil
+	}
 	// If Custom Topology is enabled we do not add node labels to the worker node
 	if s.opts.CustomTopologyEnabled {
 		return &csi.NodeGetInfoResponse{NodeId: nodeID}, nil

--- a/service/service.go
+++ b/service/service.go
@@ -586,7 +586,6 @@ func (s *service) syncIsilonConfigs(ctx context.Context) error {
 	defer syncMutex.Unlock()
 
 	configBytes, err := ioutil.ReadFile(filepath.Clean(isilonConfigFile))
-	log.Infof("file location of isilonConfigFile -> %s", isilonConfigFile)
 	if err != nil {
 		return fmt.Errorf("file ('%s') error: %v", isilonConfigFile, err)
 	}


### PR DESCRIPTION
# Description
Currently when noProbeOnStart is set to true we connect to the array to get the session and store the client.
The intention is to disable all connection attempts to the array when noProbeOnStart is set to true.
When the first request is made to either create or delete a pvc or pod, we shall attempt making a connection and create the client.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
https://github.com/dell/csm/issues/187

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- Built the changes, deployed the driver and tested the below scenarios.
a. When noProbeOnStart is set to true,
    i.  no call to array during starting of controller and driver pods.
    ii. when dynamic changes to secret is made/applied, the new config is read the clients are updated.
b. When noProbeOnStart is set to false, 
    i. connection is made to array .
    ii. when pvc creation is called, it uses the client already available and does not probe.
    iii. when dynamic changes to secret is made/applied, the new config is read the clients are updated.

