### PR TITLE
Sidecar version update and UBI image update

### DIFF
--- a/helm/csi-isilon/k8s-1.21-values.yaml
+++ b/helm/csi-isilon/k8s-1.21-values.yaml
@@ -4,22 +4,22 @@ kubeversion: "v1.21"
 images:
   # "images.attacher" defines the container images used for the csi attacher
   # container.
-  attacher: k8s.gcr.io/sig-storage/csi-attacher:v3.3.0
+  attacher: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
 
   # "images.provisioner" defines the container images used for the csi provisioner
   # container.
-  provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
+  provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
 
   # "images.snapshotter" defines the container image used for the csi snapshotter
-  snapshotter: k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.1
+  snapshotter: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
 
   # "images.registrar" defines the container images used for the csi registrar
   # container.
-  registrar: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
+  registrar: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
   
   # "images.resizer" defines the container images used for the csi resizer
   # container.
-  resizer: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
+  resizer: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
 
   # "images.externalhealthmonitorcontroller" defines the container images used for the csi external health monitor controller
   # container.

--- a/helm/csi-isilon/k8s-1.22-values.yaml
+++ b/helm/csi-isilon/k8s-1.22-values.yaml
@@ -4,22 +4,22 @@ kubeversion: "v1.22"
 images:
   # "images.attacher" defines the container images used for the csi attacher
   # container.
-  attacher: k8s.gcr.io/sig-storage/csi-attacher:v3.3.0
+  attacher: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
 
   # "images.provisioner" defines the container images used for the csi provisioner
   # container.
-  provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
+  provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
 
   # "images.snapshotter" defines the container image used for the csi snapshotter
-  snapshotter: k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.1
+  snapshotter: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
 
   # "images.registrar" defines the container images used for the csi registrar
   # container.
-  registrar: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
+  registrar: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
 
   # "images.resizer" defines the container images used for the csi resizer
   # container.
-  resizer: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
+  resizer: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
 
   # "images.externalhealthmonitorcontroller" defines the container images used for the csi external health monitor controller
   # container.

--- a/helm/csi-isilon/k8s-1.23-values.yaml
+++ b/helm/csi-isilon/k8s-1.23-values.yaml
@@ -4,22 +4,22 @@ kubeversion: "v1.23"
 images:
   # "images.attacher" defines the container images used for the csi attacher
   # container.
-  attacher: k8s.gcr.io/sig-storage/csi-attacher:v3.3.0
+  attacher: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
 
   # "images.provisioner" defines the container images used for the csi provisioner
   # container.
-  provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
+  provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
 
   # "images.snapshotter" defines the container image used for the csi snapshotter
-  snapshotter: k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.1
+  snapshotter: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1
 
   # "images.registrar" defines the container images used for the csi registrar
   # container.
-  registrar: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
+  registrar: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
   
   # "images.resizer" defines the container images used for the csi resizer
   # container.
-  resizer: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0 
+  resizer: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0 
 
   # "images.externalhealthmonitorcontroller" defines the container images used for the csi external health monitor controller
   # container.

--- a/helm/csi-isilon/templates/controller.yaml
+++ b/helm/csi-isilon/templates/controller.yaml
@@ -48,7 +48,7 @@ rules:
     verbs: ["get", "list", "watch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshotcontents"]
-    verbs: ["create", "get", "list", "watch", "update", "delete"]
+    verbs: ["create", "get", "list", "watch", "update", "delete", "patch"]
   - apiGroups: ["snapshot.storage.k8s.io"]
     resources: ["volumesnapshots"]
     verbs: ["get", "list", "watch", "update"]

--- a/overrides.mk
+++ b/overrides.mk
@@ -3,8 +3,8 @@
 #
 
 # DEFAULT values
-# ubi8/ubi-minimal:8.5-204
-DEFAULT_BASEIMAGE="registry.access.redhat.com/ubi8/ubi-minimal@sha256:e0814339ffc6c933652bed0c5f8b6416b9a3d40be2f49f95e6e4128387d2a24a"
+# ubi8/ubi-minimal:8.5-230
+DEFAULT_BASEIMAGE="registry.access.redhat.com/ubi8/ubi-minimal@sha256:3aa3f379a81013bd3264faa0af87d201cdaa5981050d78c567b48fdfd5b38bb8"
 DEFAULT_GOVERSION="1.17"
 DEFAULT_REGISTRY=""
 DEFAULT_IMAGENAME="isilon"


### PR DESCRIPTION
# Description
Side car version update as follows:
external-provisioner :  [k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0](http://k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0)
external-attacher    : [k8s.gcr.io/sig-storage/csi-attacher:v3.4.0](http://k8s.gcr.io/sig-storage/csi-attacher:v3.4.0)
external-resizer     : [k8s.gcr.io/sig-storage/csi-resizer:v1.4.0](http://k8s.gcr.io/sig-storage/csi-resizer:v1.4.0)
external-snapshotter : [k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1](http://k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.1)
node-driver-registrar: [k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.](http://k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0)

UBI image update to 8.5-230

# GitHub Issues
List the GitHub issues impacted by this PR:

| https://github.com/dell/csm/issues/183 |
| https://github.com/dell/csm/issues/182 |

# Checklist:

- [x]  I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?

- Built the changes, deployed the driver and tested the below scenarios.

1. Storage class creation 
2. PVC creation 
3. Pod creation 
4. Snapshot class creation 
5. Snapshot from the PVC is created 
6. Podman build created with latest UBI image