### PR TITLE
trivy check removed to avoid build failure

### DIFF
--- a/Dockerfile.podman
+++ b/Dockerfile.podman
@@ -29,21 +29,6 @@ RUN microdnf update -y && \
 COPY --from=builder /go/src/csi-isilon /
 ENTRYPOINT ["/csi-isilon"]
 
-# Stage to check for critical and high CVE issues via Trivy (https://github.com/aquasecurity/trivy)
-# will break image build if CRITICAL issues found
-# will print out all HIGH issues found
-FROM driver as cvescan
-COPY ./.trivyignore .
-# run trivy and clean up all traces after
-RUN microdnf install -y --enablerepo=ubi-8-baseos tar && \
-    microdnf clean all && \
-    curl https://raw.githubusercontent.com/aquasecurity/trivy/master/contrib/install.sh | sh && \
-    trivy fs -s CRITICAL --exit-code 1 / && \
-    trivy fs -s HIGH / && \
-    trivy image --reset && \
-    rm ./bin/trivy && \
-    rm ./.trivyignore
-
 # final stage
 # simple stage to use the driver image as the resultant image
 FROM driver as final


### PR DESCRIPTION
# Description
Remove trivy scan from build to avoid podman build failures

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/224 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] make build ran successfully
