### PR TITLE
CSI- Powerscale 2.3 changes

### DIFF
--- a/Dockerfile.podman
+++ b/Dockerfile.podman
@@ -37,7 +37,7 @@ LABEL vendor="Dell Inc." \
       name="csi-isilon" \
       summary="CSI Driver for Dell EMC PowerScale" \
       description="CSI Driver for provisioning persistent storage from Dell EMC PowerScale" \
-      version="2.2.0" \
+      version="2.3.0" \
       license="Apache-2.0"
 
 COPY ./licenses /licenses

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,4 +1,4 @@
-# Release Notes - CSI PowerScale v2.2.0
+# Release Notes - CSI PowerScale v2.3.0
 [![Go Report Card](https://goreportcard.com/badge/github.com/dell/csi-isilon)](https://goreportcard.com/report/github.com/dell/csi-isilon)
 [![License](https://img.shields.io/github/license/dell/csi-isilon)](https://github.com/dell/csi-isilon/blob/main/LICENSE)
 [![Docker](https://img.shields.io/docker/pulls/dellemc/csi-isilon.svg?logo=docker)](https://hub.docker.com/r/dellemc/csi-isilon)

--- a/dell-csi-helm-installer/verify-csi-isilon.sh
+++ b/dell-csi-helm-installer/verify-csi-isilon.sh
@@ -11,14 +11,14 @@
 #
 # verify-csi-isilon method
 function verify-csi-isilon() {
-  verify_k8s_versions "1.21" "1.23"
-  verify_openshift_versions "4.8" "4.9"
+  verify_k8s_versions "1.22" "1.24"
+  verify_openshift_versions "4.9" "4.10"
   verify_namespace "${NS}"
   verify_required_secrets "${RELEASE}-creds"
   verify_optional_secrets "${RELEASE}-certs"
   verify_alpha_snap_resources
   verify_snap_requirements
   verify_helm_3
-  verify_helm_values_version "2.2.0"
+  verify_helm_values_version "2.3.0"
   verify_authorization_proxy_server
 }

--- a/helm/csi-isilon/Chart.yaml
+++ b/helm/csi-isilon/Chart.yaml
@@ -1,6 +1,6 @@
 name: csi-isilon
-version: 2.2.0
-appVersion: 2.2.0
+version: 2.3.0
+appVersion: 2.3.0
 description: |
   PowerScale CSI (Container Storage Interface) driver Kubernetes
   integration. This chart includes everything required to provision via CSI as

--- a/helm/csi-isilon/driver-image.yaml
+++ b/helm/csi-isilon/driver-image.yaml
@@ -1,4 +1,4 @@
 # IT IS RECOMMENDED YOU DO NOT CHANGE THE IMAGES TO BE DOWNLOADED.
 images:
   # "images.driver" defines the container images used for the driver container.
-  driver: dellemc/csi-isilon:v2.2.0
+  driver: dellemc/csi-isilon:v2.3.0

--- a/helm/csi-isilon/k8s-1.24-values.yaml
+++ b/helm/csi-isilon/k8s-1.24-values.yaml
@@ -1,4 +1,4 @@
-kubeversion: "v1.21"
+kubeversion: "v1.24"
 
 # IT IS RECOMMENDED YOU DO NOT CHANGE THE IMAGES TO BE DOWNLOADED.
 images:
@@ -19,9 +19,8 @@ images:
   
   # "images.resizer" defines the container images used for the csi resizer
   # container.
-  resizer: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0
+  resizer: k8s.gcr.io/sig-storage/csi-resizer:v1.4.0 
 
   # "images.externalhealthmonitorcontroller" defines the container images used for the csi external health monitor controller
   # container.
   externalhealthmonitorcontroller: k8s.gcr.io/sig-storage/csi-external-health-monitor-controller:v0.4.0
-

--- a/helm/csi-isilon/values.yaml
+++ b/helm/csi-isilon/values.yaml
@@ -2,7 +2,7 @@
 ########################
 # version: version of this values file
 # Note: Do not change this value
-version: "2.2.0"
+version: "2.3.0"
 
 # CSI driver log level
 # Allowed values: "error", "warn"/"warning", "info", "debug"


### PR DESCRIPTION

# Description
Updated PowerScale version to 2.3
Added k8s 1.24 support and removed k8s 1.21

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/243 |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [X] Sanity is performed on k8s cluster
- [X] Run unit tests
