### PR TITLE
Feature/power scale changes for resiliency

### DIFF
--- a/common/constants/consts.go
+++ b/common/constants/consts.go
@@ -67,4 +67,10 @@ const (
 
 	//ParamCSILogLevel csi driver log level
 	ParamCSILogLevel = "CSI_LOG_LEVEL"
+
+	//DefaultPodmonAPIPortNumber is the port number in default to expose internal health APIs
+	DefaultPodmonAPIPortNumber = "8083"
+
+	//DefaultPodmonPollRate is the default polling frequency to check for array connectivity
+	DefaultPodmonPollRate = 60
 )

--- a/common/constants/envvars.go
+++ b/common/constants/envvars.go
@@ -89,4 +89,13 @@ const (
 
 	// EnvReplicationPrefix is used as a prefix to find out if replication is enabled
 	EnvReplicationPrefix = "X_CSI_REPLICATION_PREFIX"
+
+	//EnvPodmonEnabled indicates that podmon is enabled
+	EnvPodmonEnabled = "X_CSI_PODMON_ENABLED"
+
+	//EnvPodmonAPIPORT indicates the port to be used for exposing podmon API health
+	EnvPodmonAPIPORT = "X_CSI_PODMON_API_PORT"
+
+	//EnvPodmonArrayConnectivityPollRate indicates the polling frequency to check array connectivity
+	EnvPodmonArrayConnectivityPollRate = "X_CSI_PODMON_ARRAY_CONNECTIVITY_POLL_RATE"
 )

--- a/go.mod
+++ b/go.mod
@@ -6,11 +6,12 @@ require (
 	github.com/container-storage-interface/spec v1.5.0
 	github.com/cucumber/godog v0.10.0
 	github.com/dell/dell-csi-extensions/common v1.0.0
+	github.com/dell/dell-csi-extensions/podmon v0.1.0
 	github.com/dell/dell-csi-extensions/replication v1.1.0
 	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.1.0
 	github.com/dell/gocsi v1.5.0
 	github.com/dell/gofsutil v1.8.0
-	github.com/dell/goisilon v1.7.0
+	github.com/dell/goisilon v1.7.1-0.20220504100550-d2041717d4ed
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/golang/protobuf v1.5.2
 	github.com/google/uuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -113,6 +113,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dell/dell-csi-extensions/common v1.0.0 h1:1xANuTl8hFN6MosdW6uAwfYsRBbEBV6hz+MWOXoHbE8=
 github.com/dell/dell-csi-extensions/common v1.0.0/go.mod h1:HCs4rWiZJ1hcwfhCsr5sBsi+/5E8zuBZ+VG7qwiHOsU=
+github.com/dell/dell-csi-extensions/podmon v0.1.0 h1:7GdWXyy0n6gWhA4nuLUNvCrixq6tdkttnHqZzq2ry4g=
+github.com/dell/dell-csi-extensions/podmon v0.1.0/go.mod h1:1ZEge0qHjh39dze9PHbpGPnpfnBMiY/aKUoj/V1er6M=
 github.com/dell/dell-csi-extensions/replication v1.1.0 h1:Z+99y0CoQD4Jhl8rO5Dfz1L65cK5Ia+ClOIGfPHoGUA=
 github.com/dell/dell-csi-extensions/replication v1.1.0/go.mod h1:9BF1BUr8XF9IXLrghrznqO6J5J1TX0fcunoFZfQ0Ozc=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.1.0 h1:PlZsSnl/UfgAfdpkHbuBvL0z1ER0CWY5j5nEnCrJJ98=
@@ -123,6 +125,8 @@ github.com/dell/gofsutil v1.8.0 h1:YqsTQF3n6GAlCLVjxLkD6GmHG4mKX2SLpD64mpsAdY8=
 github.com/dell/gofsutil v1.8.0/go.mod h1:oWLiV7FmBurEie3An11SNqQ1ReyOiqjSZaXDRhm7tMc=
 github.com/dell/goisilon v1.7.0 h1:jFaY1g5cIToNQti5KsGtV5peiAWhX/FE7QwDlChtOGI=
 github.com/dell/goisilon v1.7.0/go.mod h1:ort9gaSlqh8XeyiTBhaL9ZWSymZ7u85ncjN4vckpJQA=
+github.com/dell/goisilon v1.7.1-0.20220504100550-d2041717d4ed h1:LrDBe91YYfUuqh7W1HoEX5O9Dknep+0IpGtlELBPNl0=
+github.com/dell/goisilon v1.7.1-0.20220504100550-d2041717d4ed/go.mod h1:ort9gaSlqh8XeyiTBhaL9ZWSymZ7u85ncjN4vckpJQA=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=

--- a/helm/csi-isilon/templates/controller.yaml
+++ b/helm/csi-isilon/templates/controller.yaml
@@ -413,6 +413,12 @@ spec:
               value: "{{ .Values.isiVolumePathPermissions }}"
             - name: X_CSI_ISI_NO_PROBE_ON_START
               value: "{{ .Values.noProbeOnStart }}"
+            - name: X_CSI_PODMON_ENABLED
+              value: "{{ .Values.podmon.enabled }}"
+            - name: X_CSI_PODMON_API_PORT
+              value: "{{ .Values.podmonAPIPort }}"
+            - name: X_CSI_PODMON_ARRAY_CONNECTIVITY_POLL_RATE
+              value: "{{ .Values.podmon.controller.arrayConnectivityPollRate }}"
             {{- if hasKey .Values.controller "replication" }}
             {{- if eq .Values.controller.replication.enabled true}}
             - name: X_CSI_REPLICATION_CONTEXT_PREFIX

--- a/helm/csi-isilon/templates/controller.yaml
+++ b/helm/csi-isilon/templates/controller.yaml
@@ -417,8 +417,10 @@ spec:
               value: "{{ .Values.podmon.enabled }}"
             - name: X_CSI_PODMON_API_PORT
               value: "{{ .Values.podmonAPIPort }}"
+            {{- if eq .Values.podmon.enabled true }}
             - name: X_CSI_PODMON_ARRAY_CONNECTIVITY_POLL_RATE
               value: "{{ .Values.podmon.controller.arrayConnectivityPollRate }}"
+            {{ end }}
             {{- if hasKey .Values.controller "replication" }}
             {{- if eq .Values.controller.replication.enabled true}}
             - name: X_CSI_REPLICATION_CONTEXT_PREFIX

--- a/helm/csi-isilon/templates/controller.yaml
+++ b/helm/csi-isilon/templates/controller.yaml
@@ -418,8 +418,12 @@ spec:
             - name: X_CSI_PODMON_API_PORT
               value: "{{ .Values.podmonAPIPort }}"
             {{- if eq .Values.podmon.enabled true }}
+              {{- range $key, $value := .Values.podmon.controller.args }}
+                {{- if contains "--arrayConnectivityPollRate" $value }}
             - name: X_CSI_PODMON_ARRAY_CONNECTIVITY_POLL_RATE
-              value: "{{ .Values.podmon.controller.arrayConnectivityPollRate }}"
+              value: "{{ (split "=" $value)._1 }}"
+                {{ end }}
+              {{ end }}
             {{ end }}
             {{- if hasKey .Values.controller "replication" }}
             {{- if eq .Values.controller.replication.enabled true}}

--- a/helm/csi-isilon/templates/node.yaml
+++ b/helm/csi-isilon/templates/node.yaml
@@ -129,12 +129,6 @@ spec:
             - name: driver-path
               mountPath: {{ .Values.kubeletConfigDir }}/plugins/csi-isilon
               mountPropagation: "Bidirectional"
-            - name: volumedevices-path
-              mountPath: {{ .Values.kubeletConfigDir }}/plugins/kubernetes.io/csi/volumeDevices
-              mountPropagation: "Bidirectional"
-            - name: dev
-              mountPath: /dev
-              mountPropagation: "Bidirectional"
             - name: usr-bin
               mountPath: /usr-bin
             - name: var-run
@@ -197,6 +191,12 @@ spec:
               value: "{{ .Values.maxIsilonVolumesPerNode }}"
             - name: X_CSI_HEALTH_MONITOR_ENABLED
               value: "{{ .Values.node.healthMonitor.enabled }}"
+            - name: X_CSI_PODMON_ENABLED
+              value: "{{ .Values.podmon.enabled }}"
+            - name: X_CSI_PODMON_API_PORT
+              value: "{{ .Values.podmonAPIPort }}"
+            - name: X_CSI_PODMON_ARRAY_CONNECTIVITY_POLL_RATE
+              value: "{{ .Values.podmon.controller.arrayConnectivityPollRate }}"
           volumeMounts:
             - name: driver-path
               mountPath: {{ .Values.kubeletConfigDir }}/plugins/csi-isilon

--- a/helm/csi-isilon/templates/node.yaml
+++ b/helm/csi-isilon/templates/node.yaml
@@ -129,6 +129,12 @@ spec:
             - name: driver-path
               mountPath: {{ .Values.kubeletConfigDir }}/plugins/csi-isilon
               mountPropagation: "Bidirectional"
+            - name: volumedevices-path
+              mountPath: {{ .Values.kubeletConfigDir }}/plugins/kubernetes.io/csi/volumeDevices
+              mountPropagation: "Bidirectional"
+            - name: dev
+              mountPath: /dev
+              mountPropagation: "Bidirectional"
             - name: usr-bin
               mountPath: /usr-bin
             - name: var-run

--- a/helm/csi-isilon/templates/node.yaml
+++ b/helm/csi-isilon/templates/node.yaml
@@ -202,8 +202,12 @@ spec:
             - name: X_CSI_PODMON_API_PORT
               value: "{{ .Values.podmonAPIPort }}"
             {{- if eq .Values.podmon.enabled true }}
+              {{- range $key, $value := .Values.podmon.node.args }}
+                {{- if contains "--arrayConnectivityPollRate" $value }}
             - name: X_CSI_PODMON_ARRAY_CONNECTIVITY_POLL_RATE
-              value: "{{ .Values.podmon.controller.arrayConnectivityPollRate }}"
+              value: "{{ (split "=" $value)._1 }}"
+                {{ end }}
+              {{ end }}
             {{ end }}
           volumeMounts:
             - name: driver-path

--- a/helm/csi-isilon/templates/node.yaml
+++ b/helm/csi-isilon/templates/node.yaml
@@ -201,8 +201,10 @@ spec:
               value: "{{ .Values.podmon.enabled }}"
             - name: X_CSI_PODMON_API_PORT
               value: "{{ .Values.podmonAPIPort }}"
+            {{- if eq .Values.podmon.enabled true }}
             - name: X_CSI_PODMON_ARRAY_CONNECTIVITY_POLL_RATE
               value: "{{ .Values.podmon.controller.arrayConnectivityPollRate }}"
+            {{ end }}
           volumeMounts:
             - name: driver-path
               mountPath: {{ .Values.kubeletConfigDir }}/plugins/csi-isilon

--- a/helm/csi-isilon/values.yaml
+++ b/helm/csi-isilon/values.yaml
@@ -69,6 +69,12 @@ enableCustomTopology: false
 # Default value: ReadWriteOnceWithFSType
 fsGroupPolicy: ReadWriteOnceWithFSType
 
+# podmonAPIPort: Defines the port to be used within the kubernetes cluster
+# Allowed values:
+#   Any valid and free port.
+# Default value: 8083
+podmonAPIPort: 8081
+
 # controller: configure controller pod specific parameters
 controller:
   # controllerCount: defines the number of csi-powerscale controller pods to deploy to
@@ -320,6 +326,7 @@ podmon:
   #  args:
   #    - "--csisock=unix:/var/run/csi/csi.sock"
   #    - "--labelvalue=csi-isilon"
+  #    - "--arrayConnectivityPollRate=120"
   #    - "--driverPath=csi-isilon.dellemc.com"
   #    - "--mode=controller"
   #    - "--skipArrayConnectionValidation=false"

--- a/helm/csi-isilon/values.yaml
+++ b/helm/csi-isilon/values.yaml
@@ -75,6 +75,11 @@ fsGroupPolicy: ReadWriteOnceWithFSType
 # Default value: 8083
 podmonAPIPort: 8083
 
+# maxPathLen: this parameter is used for setting the maximum Path length for the given volume.
+# Default value: 128
+# Examples: 128, 256
+maxPathLen: 128
+
 # controller: configure controller pod specific parameters
 controller:
   # controllerCount: defines the number of csi-powerscale controller pods to deploy to
@@ -340,8 +345,3 @@ podmon:
   #    - "--mode=node"
   #    - "--leaderelection=false"
   #    - "--driver-config-params=/csi-isilon-config-params/driver-config-params.yaml"
-
-# maxPathLen: this parameter is used for setting the maximum Path length for the given volume.
-# Default value: 128
-# Examples: 128, 256
-maxPathLen: 128

--- a/helm/csi-isilon/values.yaml
+++ b/helm/csi-isilon/values.yaml
@@ -73,7 +73,7 @@ fsGroupPolicy: ReadWriteOnceWithFSType
 # Allowed values:
 #   Any valid and free port.
 # Default value: 8083
-podmonAPIPort: 8081
+podmonAPIPort: 8083
 
 # controller: configure controller pod specific parameters
 controller:
@@ -326,7 +326,7 @@ podmon:
   #  args:
   #    - "--csisock=unix:/var/run/csi/csi.sock"
   #    - "--labelvalue=csi-isilon"
-  #    - "--arrayConnectivityPollRate=120"
+  #    - "--arrayConnectivityPollRate=60"
   #    - "--driverPath=csi-isilon.dellemc.com"
   #    - "--mode=controller"
   #    - "--skipArrayConnectionValidation=false"
@@ -335,6 +335,7 @@ podmon:
   #  args:
   #    - "--csisock=unix:/var/lib/kubelet/plugins/csi-isilon/csi_sock"
   #    - "--labelvalue=csi-isilon"
+  #    - "--arrayConnectivityPollRate=60"
   #    - "--driverPath=csi-isilon.dellemc.com"
   #    - "--mode=node"
   #    - "--leaderelection=false"

--- a/service/controllerNodeToArrayConnectivity.go
+++ b/service/controllerNodeToArrayConnectivity.go
@@ -58,7 +58,7 @@ func (s *service) queryArrayStatus(ctx context.Context, url string) (bool, error
 	log.Infof("API Response as struct %+v\n", statusResponse)
 	//responseObject has last success and alst attempt timestamp in Unix format
 	timeDiff := statusResponse.LastAttempt - statusResponse.LastSuccess
-	tolerance := 2 * pollingFrequencyInSeconds
+	tolerance := setPollingFrequency(ctx)
 	log.Debugf("timeDiff %v, tolerance %v", timeDiff, tolerance)
 	if timeDiff < tolerance {
 		return true, nil

--- a/service/controllerNodeToArrayConnectivity.go
+++ b/service/controllerNodeToArrayConnectivity.go
@@ -20,10 +20,10 @@ func (s *service) queryArrayStatus(ctx context.Context, url string) (bool, error
 		}
 	}()
 	log.Infof("Calling API %s with timeout %v", url, timeout)
-	ctx, cancel := context.WithTimeout(ctx, timeout)
+	timeOutCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	req, err := http.NewRequestWithContext(timeOutCtx, "GET", url, nil)
 	if err != nil {
 		log.Errorf("failed to create request for API %s due to %s ", url, err.Error())
 		return false, err

--- a/service/controllerNodeToArrayConnectivity.go
+++ b/service/controllerNodeToArrayConnectivity.go
@@ -1,0 +1,67 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	log "github.com/sirupsen/logrus"
+	"io/ioutil"
+	"net/http"
+)
+
+//queryStatus make API call to the specified url to retrieve connection status
+func (s *service) queryArrayStatus(ctx context.Context, url string) (bool, error) {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Println("panic occurred in queryStatus:", err)
+		}
+	}()
+	log.Infof("Calling API %s", url)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		log.Errorf("failed to create request for API %s due to %s ", url, err.Error())
+		return false, err
+	}
+	req.Header.Add("Accept", "application/json")
+	req.Header.Add("Content-Type", "application/json")
+	log.Infof("request is %+v", req)
+
+	client := &http.Client{
+		Transport: nil,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+		Jar:     nil,
+		Timeout: 0,
+	}
+	resp, err := client.Do(req)
+	log.Infof("response is %+v", resp)
+	if err != nil {
+		if resp != nil && resp.StatusCode == 302 {
+			log.Errorf("got redirect %+v", resp.Header.Get("Location"))
+		}
+		log.Errorf("failed to call API %s due to %s ", url, err.Error())
+		return false, err
+	}
+	defer resp.Body.Close()
+	bodyBytes, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Errorf("failed to read API response due to %s ", err.Error())
+		return false, err
+	}
+	var statusResponse ArrayConnectivityStatus
+	err = json.Unmarshal(bodyBytes, &statusResponse)
+	if err != nil {
+		log.Errorf("unable to unmarshal and determine connectivity due to %s ", err)
+		return false, err
+	}
+	log.Infof("API Response as struct %+v\n", statusResponse)
+	//responseObject has last success and alst attempt timestamp in Unix format
+	timeDiff := statusResponse.LastAttempt - statusResponse.LastSuccess
+	tolerance := 2 * pollingFrequencyInSeconds
+	log.Debugf("timeDiff %v, tolerance %v", timeDiff, tolerance)
+	if timeDiff < tolerance {
+		return true, nil
+	}
+	return false, nil
+}

--- a/service/csi_extension_server.go
+++ b/service/csi_extension_server.go
@@ -1,0 +1,88 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"github.com/dell/csi-isilon/common/utils"
+	podmon "github.com/dell/dell-csi-extensions/podmon"
+)
+
+func (s *service) ValidateVolumeHostConnectivity(ctx context.Context, req *podmon.ValidateVolumeHostConnectivityRequest) (*podmon.ValidateVolumeHostConnectivityResponse, error) {
+	ctx, log, _ := GetRunIDLog(ctx)
+	log.Infof("ValidateVolumeHostConnectivity called %+v", req)
+	rep := &podmon.ValidateVolumeHostConnectivityResponse{
+		Messages: make([]string, 0),
+	}
+
+	if (len(req.GetVolumeIds()) == 0 || len(req.GetVolumeIds()) == 0) && req.GetNodeId() == "" {
+		// This is a nop call just testing the interface is present
+		rep.Messages = append(rep.Messages, "ValidateVolumeHostConnectivity is implemented")
+		return rep, nil
+	}
+
+	systemIDs := make(map[string]bool)
+	systemID := req.GetArrayId()
+	if systemID == "" {
+		foundOne := s.getArrayIdsFromVolumes(ctx, systemIDs, req.GetVolumeIds())
+		if !foundOne {
+			systemID = s.defaultIsiClusterName
+			systemIDs[systemID] = true
+		}
+	}
+
+	if req.GetNodeId() == "" {
+		return nil, fmt.Errorf("The NodeID is a required field")
+	}
+
+	clusterName := s.defaultIsiClusterName
+
+	//Get cluster config
+	isiConfig, err := s.getIsilonConfig(ctx, &clusterName)
+	if err != nil {
+		log.Error("Failed to get Isilon config with error ", err.Error())
+		return nil, err
+	}
+
+	//set cluster context
+	ctx, log = setClusterContext(ctx, clusterName)
+	log.Debugf("Cluster Name: %v", clusterName)
+
+	rep.Connected = true
+
+	clients, err := isiConfig.isiSvc.IsIOinProgress(ctx)
+
+	for _, c := range clients.ClientsList {
+		if c.Protocol == "nfs3" || c.Protocol == "nfs4" {
+			_, _, clientIP, _ := utils.ParseNodeID(ctx, req.GetNodeId())
+			if clientIP == c.RemoteAddr {
+				rep.IosInProgress = true
+			}
+		}
+	}
+
+	log.Infof("ValidateVolumeHostConnectivity reply %+v", rep)
+	return rep, nil
+}
+
+func (s *service) getArrayIdsFromVolumes(ctx context.Context, systemIDs map[string]bool, requestVolumeIds []string) bool {
+	ctx, log, _ := GetRunIDLog(ctx)
+	var err error
+	var systemID string
+	var foundAtLeastOne bool
+	for _, volumeID := range requestVolumeIds {
+		// Extract clusterName from the volume ID (if any volumes in the request)
+		if _, _, _, systemID, err = utils.ParseNormalizedVolumeID(ctx, volumeID); err != nil {
+			log.Warnf("Error getting Cluster Name for %s - %s", volumeID, err.Error())
+		}
+		if systemID != "" {
+			if _, exists := systemIDs[systemID]; !exists {
+				foundAtLeastOne = true
+				systemIDs[systemID] = true
+				log.Infof("Using systemID from %s, %s", volumeID, systemID)
+			}
+		} else {
+			log.Infof("Could not extract systemID from %s", volumeID)
+		}
+	}
+	return foundAtLeastOne
+}

--- a/service/csi_extension_server.go
+++ b/service/csi_extension_server.go
@@ -59,15 +59,16 @@ func (s *service) ValidateVolumeHostConnectivity(ctx context.Context, req *podmo
 
 	clients, err := isiConfig.isiSvc.IsIOinProgress(ctx)
 
-	for _, c := range clients.ClientsList {
-		if c.Protocol == "nfs3" || c.Protocol == "nfs4" {
-			_, _, clientIP, _ := utils.ParseNodeID(ctx, req.GetNodeId())
-			if clientIP == c.RemoteAddr {
-				rep.IosInProgress = true
+	if clients != nil {
+		for _, c := range clients.ClientsList {
+			if c.Protocol == "nfs3" || c.Protocol == "nfs4" {
+				_, _, clientIP, _ := utils.ParseNodeID(ctx, req.GetNodeId())
+				if clientIP == c.RemoteAddr {
+					rep.IosInProgress = true
+				}
 			}
 		}
 	}
-
 	log.Infof("ValidateVolumeHostConnectivity reply %+v", rep)
 	return rep, nil
 }

--- a/service/csi_extension_server.go
+++ b/service/csi_extension_server.go
@@ -32,7 +32,7 @@ func (s *service) ValidateVolumeHostConnectivity(ctx context.Context, req *podmo
 	}
 
 	if req.GetNodeId() == "" {
-		return nil, fmt.Errorf("The NodeID is a required field")
+		return nil, fmt.Errorf("the NodeID is a required field")
 	}
 
 	// Go through each of the systemIDs
@@ -53,6 +53,7 @@ func (s *service) ValidateVolumeHostConnectivity(ctx context.Context, req *podmo
 
 		// check if any IO is inProgress for the current systemID/array
 		clients, err := isiConfig.isiSvc.IsIOInProgress(ctx)
+		log.Debugf("fetched clients %+v", clients)
 		if clients != nil {
 			for _, c := range clients.ClientsList {
 				if c.Protocol == "nfs3" || c.Protocol == "nfs4" {

--- a/service/csi_extension_server.go
+++ b/service/csi_extension_server.go
@@ -57,7 +57,7 @@ func (s *service) ValidateVolumeHostConnectivity(ctx context.Context, req *podmo
 		}
 	}
 
-	clients, err := isiConfig.isiSvc.IsIOinProgress(ctx)
+	clients, err := isiConfig.isiSvc.IsIOInProgress(ctx)
 
 	if clients != nil {
 		for _, c := range clients.ClientsList {

--- a/service/features/csi_extension.feature
+++ b/service/features/csi_extension.feature
@@ -1,0 +1,30 @@
+Feature: Isilon CSI interface
+  As a consumer of the CSI interface
+  I want to test service methods
+  So that they are known to work
+
+@podmon
+@v1.0.0
+  Scenario: Call ValidateConnectivity
+    Given a Isilon service
+    When I call Probe
+    And I call CreateVolume "volume1"
+    And a valid CreateVolumeResponse is returned
+    And I call ValidateConnectivity
+    Then the error contains "none"
+
+
+  Scenario: Call ValidateConnectivity with no Node
+    Given a Isilon service
+    When I call CreateVolume "volume1"
+    And I induce error "no-nodeId"
+    And I call ValidateConnectivity
+    Then the error contains "The NodeID is a required field"
+
+
+  Scenario: Call ValidateConnectivity with no Volume no Node
+    Given a Isilon service
+    And I induce error "no-volume-no-nodeId"
+    And I call ValidateConnectivity
+    Then the error contains "ValidateVolumeHostConnectivity is implemented"
+

--- a/service/isiService.go
+++ b/service/isiService.go
@@ -400,13 +400,13 @@ func (svc *isiService) GetStatistics(ctx context.Context, keys []string) (isi.St
 	return stat, nil
 }
 
-func (svc *isiService) IsIOinProgress(ctx context.Context) (isi.Clients, error) {
+func (svc *isiService) IsIOInProgress(ctx context.Context) (isi.Clients, error) {
 	// Fetch log handler
 	log := utils.GetRunIDLogger(ctx)
 
 	var clients isi.Clients
 	var err error
-	if clients, err = svc.client.IsIOinProgress(ctx); err != nil {
+	if clients, err = svc.client.IsIOInProgress(ctx); err != nil {
 		log.Errorf("failed to get array Clients '%s'", err)
 		return nil, err
 	}

--- a/service/isiService.go
+++ b/service/isiService.go
@@ -400,6 +400,19 @@ func (svc *isiService) GetStatistics(ctx context.Context, keys []string) (isi.St
 	return stat, nil
 }
 
+func (svc *isiService) IsIOinProgress(ctx context.Context) (isi.Clients, error) {
+	// Fetch log handler
+	log := utils.GetRunIDLogger(ctx)
+
+	var clients isi.Clients
+	var err error
+	if clients, err = svc.client.IsIOinProgress(ctx); err != nil {
+		log.Errorf("failed to get array Clients '%s'", err)
+		return nil, err
+	}
+	return clients, nil
+}
+
 func (svc *isiService) IsVolumeExistent(ctx context.Context, isiPath, volID, name string) bool {
 	// Fetch log handler
 	log := utils.GetRunIDLogger(ctx)

--- a/service/mock/statistics/IO_not_inprogress.txt
+++ b/service/mock/statistics/IO_not_inprogress.txt
@@ -1,0 +1,52 @@
+{
+    "client": [
+        {
+            "class": "other",
+            "in": 7.800000190734863,
+            "in_avg": 39.0,
+            "in_max": 39,
+            "in_min": 39,
+            "local_addr": "*",
+            "local_name": "UNKNOWN",
+            "node": 1,
+            "num_operations": 1,
+            "operation_rate": 0.2000000029802322,
+            "out": 0.0,
+            "out_avg": 0.0,
+            "out_max": 0,
+            "out_min": 0,
+            "protocol": "siq",
+            "remote_addr": "*",
+            "remote_name": "UNKNOWN",
+            "time": 1651131929,
+            "time_avg": 7.0,
+            "time_max": 7,
+            "time_min": 7,
+            "user": {}
+        },
+        {
+            "class": "other",
+            "in": 0.0,
+            "in_avg": 0.0,
+            "in_max": 0,
+            "in_min": 0,
+            "local_addr": "*",
+            "local_name": "UNKNOWN",
+            "node": 2,
+            "num_operations": 1,
+            "operation_rate": 0.2000000029802322,
+            "out": 7.800000190734863,
+            "out_avg": 39.0,
+            "out_max": 39,
+            "out_min": 39,
+            "protocol": "siq",
+            "remote_addr": "*",
+            "remote_name": "UNKNOWN",
+            "time": 1651131929,
+            "time_avg": 68.0,
+            "time_max": 68,
+            "time_min": 68,
+            "user": {}
+        }
+    ]
+}

--- a/service/nodeConnectivityChecker.go
+++ b/service/nodeConnectivityChecker.go
@@ -1,0 +1,200 @@
+package service
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/dell/csi-isilon/common/constants"
+	"github.com/dell/csi-isilon/common/utils"
+	csictx "github.com/dell/gocsi/context"
+	"github.com/gorilla/mux"
+	log "github.com/sirupsen/logrus"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	nodeStatus  = "/node-status"
+	arrayStatus = "/array-status"
+)
+
+// pollingFrequency in seconds
+var pollingFrequencyInSeconds int64
+var apiPort string
+
+// probeStatus map[string]ArrayConnectivityStatus
+var probeStatus *sync.Map
+
+//ArrayConnectivityStatus Status of the array probe
+type ArrayConnectivityStatus struct {
+	LastSuccess int64 `json:"lastSuccess"` // connectivity status
+	LastAttempt int64 `json:"lastAttempt"` // last timestamp attempted to check connectivity
+}
+
+func (s *service) setAPIPort(ctx context.Context) {
+	if port, ok := csictx.LookupEnv(ctx, constants.EnvPodmonAPIPORT); ok {
+		log.Debugf("set podmon API port to %s", apiPort)
+		apiPort = ":" + port
+	} else {
+		// If the port number cannot be fetched, set it to default
+		apiPort = ":" + constants.DefaultPodmonAPIPortNumber
+		log.Debugf("set podmon API port to default %s", apiPort)
+	}
+	fmt.Printf("set podmon API port to %s", apiPort)
+}
+
+func (s *service) setPollingFrequency(ctx context.Context) int64 {
+	pollRate, err := utils.ParseInt64FromContext(ctx, constants.EnvPodmonArrayConnectivityPollRate)
+	if err != nil {
+		log.Debugf("set default pollingFrequency %d seconds", constants.DefaultPodmonPollRate)
+		return constants.DefaultPodmonPollRate
+	}
+	log.Debugf("set pollingFrequency as %d seconds", pollRate)
+	//TODO:: fetch poll rate from env
+	return constants.DefaultPodmonPollRate
+	//return pollRate
+}
+
+// MarshalSyncMapToJSON marshal the sync Map to Json
+func MarshalSyncMapToJSON(m *sync.Map) ([]byte, error) {
+	tmpMap := make(map[string]ArrayConnectivityStatus)
+	m.Range(func(k, v interface{}) bool {
+		tmpMap[k.(string)] = v.(ArrayConnectivityStatus)
+		return true
+	})
+	log.Debugf("map value is %+v", tmpMap)
+	return json.Marshal(tmpMap)
+}
+
+//StartAPIService reads nodes to array status periodically
+func (s *service) startAPIService(ctx context.Context) {
+	isPodmonEnabled := utils.ParseBooleanFromContext(ctx, constants.EnvPodmonEnabled)
+	if !isPodmonEnabled {
+		log.Infof("podmon not enabled")
+		//TODO: Check if podmon is enabled
+		//return
+	}
+
+	pollingFrequencyInSeconds = s.setPollingFrequency(ctx)
+
+	//start methods based on mode
+	if strings.EqualFold(s.mode, constants.ModeController) {
+		return
+	}
+	s.setAPIPort(ctx)
+	s.startNodeToArrayConnectivityCheck(ctx)
+	s.apiRouter(ctx)
+}
+
+//apiRouter serves http requests
+func (s *service) apiRouter(ctx context.Context) {
+	log.Infof("starting http server on port %s", apiPort)
+	//create a new router
+	router := mux.NewRouter()
+	//route to connectivity status
+	router.HandleFunc(nodeStatus, nodeHealth).Methods("GET")
+	router.HandleFunc(arrayStatus, connectivityStatus).Methods("GET")
+	router.HandleFunc(arrayStatus+"/"+"{arrayId}", getArrayConnectivityStatus).Methods("GET")
+	//start http server to serve requests
+	http.ListenAndServe(apiPort, router)
+}
+
+// GetArrayConnectivityStatus lists status of the requested array
+func getArrayConnectivityStatus(w http.ResponseWriter, r *http.Request) {
+	arrayID := mux.Vars(r)["arrayId"]
+	log.Infof("GetArrayConnectivityStatus called for array %s \n", arrayID)
+	status, found := probeStatus.Load(arrayID)
+	if !found {
+		//specify status code
+		w.WriteHeader(http.StatusNotFound)
+		w.Header().Set("Content-Type", "application/json")
+		//update response writer
+		fmt.Fprintf(w, "array %s not found \n", arrayID)
+		return
+	}
+	//convert struct to JSON
+	jsonResponse, err := json.Marshal(status)
+	if err != nil {
+		log.Errorf("error %s during marshaling to json", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		return
+	}
+	log.Infof("sending response %s for array %s \n", status, arrayID)
+	//update response
+	w.WriteHeader(http.StatusOK)
+	w.Write(jsonResponse)
+}
+
+// NodeHealth states if node is up
+func nodeHealth(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(http.StatusOK)
+	w.Header().Set("Content-Type", "application/json")
+	fmt.Fprintf(w, "node is up and running \n")
+}
+
+// ConnectivityStatus Returns array connectivity status
+func connectivityStatus(w http.ResponseWriter, r *http.Request) {
+	log.Infof("ConnectivityStatus called, urr status is %v \n", probeStatus)
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+
+	//convert struct to JSON
+	jsonResponse, err := MarshalSyncMapToJSON(probeStatus)
+	if err != nil {
+		log.Errorf("error %s during marshaling to json", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		return
+	}
+	log.Infof("ConnectivityStatus called, marshalled  status is %v \n", jsonResponse)
+	tmpMap := make(map[string]ArrayConnectivityStatus)
+	probeStatus.Range(func(k, v interface{}) bool {
+		tmpMap[k.(string)] = v.(ArrayConnectivityStatus)
+		return true
+	})
+	log.Infof("ConnectivityStatus called, status is %v \n", tmpMap)
+	w.Write(jsonResponse)
+
+}
+
+//startNodeToArrayConnectivityCheck runs probe to test connectivity from node to array
+//updates probeStatus map[array]ArrayConnectivityStatus
+func (s *service) startNodeToArrayConnectivityCheck(ctx context.Context) error {
+	log.Info("startNodeToArrayConnectivityCheck called")
+	probeStatus = new(sync.Map)
+	var status ArrayConnectivityStatus
+	//ctx, log := GetLogger(ctx)
+	isilonClusters := s.getIsilonClusters()
+	for _, cluster := range isilonClusters {
+		go func(cluster *IsilonClusterConfig) {
+			for {
+				log.Debugf("Running probe for cluster %s at time %v \n", cluster.ClusterName, time.Now())
+				if existingStatus, ok := probeStatus.Load(cluster.ClusterName); !ok {
+					log.Debugf("%s not in probeStatus ", cluster.ClusterName)
+				} else {
+					if status, ok = existingStatus.(ArrayConnectivityStatus); !ok {
+						log.Errorf("failed to extract ArrayConnectivityStatus for cluster '%s'", cluster.ClusterName)
+					}
+				}
+				log.Infof("status is %+v", status)
+				err := s.nodeProbe(ctx, cluster)
+				if err == nil {
+					log.Debugf("Probe successful for %s", cluster.ClusterName)
+					status.LastSuccess = time.Now().Unix()
+				} else {
+					log.Debugf("Probe failed for isilon cluster '%s' error:'%s'", cluster.ClusterName, err)
+				}
+				status.LastAttempt = time.Now().Unix()
+				log.Infof("cluster %s , storing status %+v", cluster.ClusterName, status)
+				probeStatus.Store(cluster.ClusterName, status)
+				st, ok := probeStatus.Load(cluster.ClusterName)
+				log.Infof("cluster %s , reading probeStatus is %+v, %v", cluster.ClusterName, st, ok)
+				time.Sleep(time.Second * time.Duration(pollingFrequencyInSeconds))
+			}
+		}(cluster)
+	}
+	return nil
+}

--- a/service/nodeConnectivityChecker.go
+++ b/service/nodeConnectivityChecker.go
@@ -162,7 +162,6 @@ func connectivityStatus(w http.ResponseWriter, r *http.Request) {
 		return true
 	})
 	log.Infof("ConnectivityStatus called, status is %v \n", tmpMap)
-	w.Write(jsonResponse)
 	_, err = w.Write(jsonResponse)
 	if err != nil {
 		log.Errorf("unable to write response %s", err)

--- a/service/nodeConnectivityChecker.go
+++ b/service/nodeConnectivityChecker.go
@@ -187,7 +187,7 @@ func (s *service) startNodeToArrayConnectivityCheck(ctx context.Context) {
 						log.Errorf("failed to extract ArrayConnectivityStatus for cluster '%s'", cluster.ClusterName)
 					}
 				}
-				log.Infof("status is %+v", status)
+				log.Debugf("cluster %s , status is %+v", cluster.ClusterName, status)
 				err := s.nodeProbe(ctx, cluster)
 				if err == nil {
 					log.Debugf("Probe successful for %s", cluster.ClusterName)
@@ -196,10 +196,8 @@ func (s *service) startNodeToArrayConnectivityCheck(ctx context.Context) {
 					log.Debugf("Probe failed for isilon cluster '%s' error:'%s'", cluster.ClusterName, err)
 				}
 				status.LastAttempt = time.Now().Unix()
-				log.Infof("cluster %s , storing status %+v", cluster.ClusterName, status)
+				log.Debugf("cluster %s , storing status %+v", cluster.ClusterName, status)
 				probeStatus.Store(cluster.ClusterName, status)
-				st, ok := probeStatus.Load(cluster.ClusterName)
-				log.Infof("cluster %s , reading probeStatus is %+v, %v", cluster.ClusterName, st, ok)
 				time.Sleep(time.Second * time.Duration(pollingFrequencyInSeconds/2))
 			}
 		}(cluster)

--- a/service/nodeConnectivityChecker.go
+++ b/service/nodeConnectivityChecker.go
@@ -49,8 +49,8 @@ func setAPIPort(ctx context.Context) {
 //reads the pollingFrequency from Env, sets default if not found
 func setPollingFrequency(ctx context.Context) int64 {
 	pollRate, err := utils.ParseInt64FromContext(ctx, constants.EnvPodmonArrayConnectivityPollRate)
-	if err != nil {
-		log.Debugf("use default pollingFrequency %d seconds, err %s", constants.DefaultPodmonPollRate, err)
+	if err != nil || pollRate == 0 {
+		log.Debugf("use default pollingFrequency %d seconds, err %v", constants.DefaultPodmonPollRate, err)
 		return constants.DefaultPodmonPollRate
 	}
 	log.Debugf("use pollingFrequency as %d seconds", pollRate)

--- a/service/nodeConnectivityChecker.go
+++ b/service/nodeConnectivityChecker.go
@@ -68,11 +68,11 @@ func MarshalSyncMapToJSON(m *sync.Map) ([]byte, error) {
 	return json.Marshal(tmpMap)
 }
 
-//StartAPIService reads nodes to array status periodically
+//startAPIService reads nodes to array status periodically
 func (s *service) startAPIService(ctx context.Context) {
 	isPodmonEnabled := utils.ParseBooleanFromContext(ctx, constants.EnvPodmonEnabled)
 	if !isPodmonEnabled {
-		log.Info("podmon not enabled")
+		log.Info("podmon is not enabled")
 		return
 	}
 
@@ -104,7 +104,7 @@ func (s *service) apiRouter(ctx context.Context) {
 	}
 }
 
-// GetArrayConnectivityStatus lists status of the requested array
+//getArrayConnectivityStatus lists status of the requested array
 func getArrayConnectivityStatus(w http.ResponseWriter, r *http.Request) {
 	arrayID := mux.Vars(r)["arrayId"]
 	log.Infof("GetArrayConnectivityStatus called for array %s \n", arrayID)
@@ -117,7 +117,7 @@ func getArrayConnectivityStatus(w http.ResponseWriter, r *http.Request) {
 		fmt.Fprintf(w, "array %s not found \n", arrayID)
 		return
 	}
-	//convert struct to JSON
+	//convert status struct to JSON
 	jsonResponse, err := json.Marshal(status)
 	if err != nil {
 		log.Errorf("error %s during marshaling to json", err)
@@ -125,7 +125,7 @@ func getArrayConnectivityStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		return
 	}
-	log.Infof("sending response %s for array %s \n", status, arrayID)
+	log.Infof("sending response %+v for array %s \n", status, arrayID)
 	//update response
 	w.WriteHeader(http.StatusOK)
 	_, err = w.Write(jsonResponse)
@@ -134,16 +134,16 @@ func getArrayConnectivityStatus(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// NodeHealth states if node is up
+//nodeHealth states if node is up
 func nodeHealth(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	w.Header().Set("Content-Type", "application/json")
 	fmt.Fprintf(w, "node is up and running \n")
 }
 
-// ConnectivityStatus Returns array connectivity status
+//connectivityStatus Returns array connectivity status
 func connectivityStatus(w http.ResponseWriter, r *http.Request) {
-	log.Infof("ConnectivityStatus called, urr status is %v \n", probeStatus)
+	log.Infof("connectivityStatus called, urr status is %v \n", probeStatus)
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(http.StatusOK)
 
@@ -155,13 +155,7 @@ func connectivityStatus(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		return
 	}
-	log.Infof("ConnectivityStatus called, marshalled  status is %v \n", jsonResponse)
-	tmpMap := make(map[string]ArrayConnectivityStatus)
-	probeStatus.Range(func(k, v interface{}) bool {
-		tmpMap[k.(string)] = v.(ArrayConnectivityStatus)
-		return true
-	})
-	log.Infof("ConnectivityStatus called, status is %v \n", tmpMap)
+	log.Info("sending connectivityStatus for all clusters ")
 	_, err = w.Write(jsonResponse)
 	if err != nil {
 		log.Errorf("unable to write response %s", err)
@@ -169,38 +163,54 @@ func connectivityStatus(w http.ResponseWriter, r *http.Request) {
 
 }
 
-//startNodeToArrayConnectivityCheck runs probe to test connectivity from node to array
-//updates probeStatus map[array]ArrayConnectivityStatus
+//startNodeToArrayConnectivityCheck starts connectivityTest as one goroutine for each cluster
 func (s *service) startNodeToArrayConnectivityCheck(ctx context.Context) {
 	log.Debug("startNodeToArrayConnectivityCheck called")
 	probeStatus = new(sync.Map)
-	var status ArrayConnectivityStatus
 	isilonClusters := s.getIsilonClusters()
 	for _, cluster := range isilonClusters {
-		go func(cluster *IsilonClusterConfig) {
-			for {
-				log.Debugf("Running probe for cluster %s at time %v \n", cluster.ClusterName, time.Now())
-				if existingStatus, ok := probeStatus.Load(cluster.ClusterName); !ok {
-					log.Debugf("%s not in probeStatus ", cluster.ClusterName)
-				} else {
-					if status, ok = existingStatus.(ArrayConnectivityStatus); !ok {
-						log.Errorf("failed to extract ArrayConnectivityStatus for cluster '%s'", cluster.ClusterName)
-					}
-				}
-				log.Debugf("cluster %s , status is %+v", cluster.ClusterName, status)
-				err := s.nodeProbe(ctx, cluster)
-				if err == nil {
-					log.Debugf("Probe successful for %s", cluster.ClusterName)
-					status.LastSuccess = time.Now().Unix()
-				} else {
-					log.Debugf("Probe failed for isilon cluster '%s' error:'%s'", cluster.ClusterName, err)
-				}
-				status.LastAttempt = time.Now().Unix()
-				log.Debugf("cluster %s , storing status %+v", cluster.ClusterName, status)
-				probeStatus.Store(cluster.ClusterName, status)
-				time.Sleep(time.Second * time.Duration(pollingFrequencyInSeconds/2))
-			}
-		}(cluster)
+		//start one goroutine for each cluster, so each cluster's nodeProbe is run concurrently
+		go s.testConnectivityAndUpdateStatus(ctx, cluster, timeout)
 	}
 	log.Infof("startNodeToArrayConnectivityCheck is running probes at pollingFrequency %d ", pollingFrequencyInSeconds/2)
+}
+
+//testConnectivityAndUpdateStatus runs probe to test connectivity from node to array
+//updates probeStatus map[array]ArrayConnectivityStatus
+func (s *service) testConnectivityAndUpdateStatus(ctx context.Context, cluster *IsilonClusterConfig, timeout time.Duration) {
+	defer func() {
+		if err := recover(); err != nil {
+			log.Errorf("panic occurred in testConnectivityAndUpdateStatus:%s for clsuter %s", err, cluster)
+		}
+		//if panic occurs restart
+		go s.testConnectivityAndUpdateStatus(ctx, cluster, timeout)
+	}()
+	var status ArrayConnectivityStatus
+	//add timeout to context
+	ctx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	for {
+		log.Debugf("Running probe for cluster %s at time %v \n", cluster.ClusterName, time.Now())
+		if existingStatus, ok := probeStatus.Load(cluster.ClusterName); !ok {
+			log.Debugf("%s not in probeStatus ", cluster.ClusterName)
+		} else {
+			if status, ok = existingStatus.(ArrayConnectivityStatus); !ok {
+				log.Errorf("failed to extract ArrayConnectivityStatus for cluster '%s'", cluster.ClusterName)
+			}
+		}
+		log.Debugf("cluster %s , status is %+v", cluster.ClusterName, status)
+		//run nodeProbe to test connectivity
+		err := s.nodeProbe(ctx, cluster)
+		if err == nil {
+			log.Debugf("Probe successful for %s", cluster.ClusterName)
+			status.LastSuccess = time.Now().Unix()
+		} else {
+			log.Debugf("Probe failed for isilon cluster '%s' error:'%s'", cluster.ClusterName, err)
+		}
+		status.LastAttempt = time.Now().Unix()
+		log.Debugf("cluster %s , storing status %+v", cluster.ClusterName, status)
+		probeStatus.Store(cluster.ClusterName, status)
+		//sleep for half the pollingFrequency and run check again
+		time.Sleep(time.Second * time.Duration(pollingFrequencyInSeconds/2))
+	}
 }

--- a/service/service.go
+++ b/service/service.go
@@ -42,6 +42,7 @@ import (
 	"github.com/dell/csi-isilon/common/utils"
 	"github.com/dell/csi-isilon/core"
 	commonext "github.com/dell/dell-csi-extensions/common"
+	podmon "github.com/dell/dell-csi-extensions/podmon"
 	csiext "github.com/dell/dell-csi-extensions/replication"
 	vgsext "github.com/dell/dell-csi-extensions/volumeGroupSnapshot"
 	"github.com/dell/gocsi"
@@ -534,9 +535,13 @@ func (s *service) BeforeServe(
 	return s.probeOnStart(ctx)
 }
 
+// RegisterAdditionalServers registers any additional grpc services that use the CSI socket.
 func (s *service) RegisterAdditionalServers(server *grpc.Server) {
+	_, log := GetLogger(context.Background())
+	log.Info("Registering additional GRPC servers")
 	csiext.RegisterReplicationServer(server, s)
 	vgsext.RegisterVolumeGroupSnapshotServer(server, s)
+	podmon.RegisterPodmonServer(server, s)
 }
 
 func (s *service) loadIsilonConfigs(ctx context.Context, configFile string) error {
@@ -629,7 +634,7 @@ func (s *service) syncIsilonConfigs(ctx context.Context) error {
 
 		s.defaultIsiClusterName = defaultClusterName
 		if s.defaultIsiClusterName == "" {
-			log.Warnf("no default cluster name/config available")
+			log.Errorf("no default cluster name/config available")
 		}
 	} else {
 		return errors.New("isilon cluster details are not provided in isilon-creds secret")

--- a/service/service.go
+++ b/service/service.go
@@ -531,6 +531,7 @@ func (s *service) BeforeServe(
 
 	// Dynamically load the config
 	go s.loadIsilonConfigs(ctx, isilonConfigFile)
+	go s.startAPIService(ctx)
 
 	return s.probeOnStart(ctx)
 }

--- a/service/step_handlers_test.go
+++ b/service/step_handlers_test.go
@@ -34,29 +34,35 @@ var (
 	debug bool
 
 	stepHandlersErrors struct {
-		FindVolumeIDError          bool
-		GetVolByIDError            bool
-		GetStoragePoolsError       bool
-		GetStatisticsError         bool
-		CreateSnapshotError        bool
-		RemoveVolumeError          bool
-		InstancesError             bool
-		VolInstanceError           bool
-		StatsError                 bool
-		StartingTokenInvalidError  bool
-		GetSnapshotError           bool
-		DeleteSnapshotError        bool
-		ExportNotFoundError        bool
-		VolumeNotExistError        bool
-		CreateQuotaError           bool
-		UpdateQuotaError           bool
-		CreateExportError          bool
-		GetExportInternalError     bool
-		GetExportByIDNotFoundError bool
-		UnexportError              bool
-		DeleteQuotaError           bool
-		QuotaNotFoundError         bool
-		DeleteVolumeError          bool
+		FindVolumeIDError           bool
+		GetVolByIDError             bool
+		GetStoragePoolsError        bool
+		GetStatisticsError          bool
+		CreateSnapshotError         bool
+		RemoveVolumeError           bool
+		InstancesError              bool
+		VolInstanceError            bool
+		StatsError                  bool
+		StartingTokenInvalidError   bool
+		GetSnapshotError            bool
+		DeleteSnapshotError         bool
+		ExportNotFoundError         bool
+		VolumeNotExistError         bool
+		CreateQuotaError            bool
+		UpdateQuotaError            bool
+		CreateExportError           bool
+		GetExportInternalError      bool
+		GetExportByIDNotFoundError  bool
+		UnexportError               bool
+		DeleteQuotaError            bool
+		QuotaNotFoundError          bool
+		DeleteVolumeError           bool
+		PodmonControllerProbeError  bool
+		PodmonNodeProbeError        bool
+		PodmonVolumeError           bool
+		PodmonVolumeStatisticsError bool
+		PodmonNoNodeIDError         bool
+		PodmonNoVolumeNoNodeIDError bool
 	}
 )
 
@@ -94,6 +100,7 @@ func getRouter() http.Handler {
 	isilonRouter.HandleFunc("/platform/2/protocols/nfs/exports/", handleGetExportsWithResume).Methods("GET").Queries("resume", "")
 	isilonRouter.HandleFunc("/platform/2/protocols/nfs/exports/", handleGetExports).Methods("GET")
 	isilonRouter.HandleFunc("/platform/3/statistics/current", handleStatistics)
+	isilonRouter.HandleFunc("/platform/3/statistics/summary/client", handleIOInProgress).Methods("GET")
 	isilonRouter.HandleFunc("/platform/3/cluster/config/", handleGetClusterConfig)
 	// Do NOT change the sequence of the following lines, the first is the subset of the second,
 	// thus if the sequence is reversed, the query with "metadata" will be wrongly resolved.
@@ -392,6 +399,15 @@ func handleModifyExport(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusNoContent)
 	// response body is empty
 	w.Write([]byte(""))
+}
+
+func handleIOInProgress(w http.ResponseWriter, r *http.Request) {
+	if testControllerHasNoConnection || testNodeHasNoConnection {
+		w.WriteHeader(http.StatusRequestTimeout)
+		return
+	}
+	w.WriteHeader(http.StatusOK)
+	w.Write(readFromFile("mock/statistics/IO_not_inprogress.txt"))
 }
 
 // handleStatistics implements GET /platform/3/statistics


### PR DESCRIPTION
# Description
This PR enables resiliency for csi-powerscale driver.
Below are the changes.
 
common/constants/consts.go  - added default values
common/constants/envvars.go  - added env variable constants

helm/csi-isilon/values.yaml  - specifies API port and arrayConnectivityPollRate
helm/csi-isilon/templates/controller.yaml - read the arrayConnectivityPollRate specified in podmon
helm/csi-isilon/templates/node.yaml - read the arrayConnectivityPollRate specified in podmon

As there is no Isilon platform support to test connecitivity, the below files poll the array from the k8s node and expose an API to test the connecitivity using probes.
service/controllerNodeToArrayConnectivity.go  - forms the url and queries worker node for connecitity to array
service/nodeConnectivityChecker.go - periodically runs probe and returns the status when API is called.
service/service.go - starts the API connecitivity check

service/csi_extension_server.go - implements csi extension to enable podmon

service/isiService.go - calls API using gopowerscale lib to fetch active clients running IOs

# GitHub Issues
https://github.com/dell/csm/issues/262

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Built the changes and tested the regular flow with podmon disabled.
- [x] When podmon is enabled, able to see taint applied if k8s node goes down.
- [x] When podmon is enabled, able to connectivity probe being run in logs.
- [x] When podmon is enabled, able to check IOs being detected in logs.

