### PR TITLE
Break association when deleting protection group

### DIFF
--- a/service/replication.go
+++ b/service/replication.go
@@ -280,8 +280,19 @@ func (s *service) DeleteStorageProtectionGroup(ctx context.Context,
 			return nil, status.Errorf(codes.Internal, "VG '%s' is not empty", isiPath)
 		}
 	}
+
 	ppName := strings.ReplaceAll(strings.ReplaceAll(strings.TrimPrefix(isiPath, isiConfig.IsiPath), "/", ""), ".", "-")
 	err = isiConfig.isiSvc.client.SyncPolicy(ctx, ppName)
+
+	log.Info("Breaking association on SRC site")
+	err = isiConfig.isiSvc.client.BreakAssociation(ctx, ppName)
+	e, ok := err.(*isiApi.JSONError)
+	if err != nil {
+		if (ok && e.StatusCode != 404) || !strings.Contains(err.Error(), "not found") {
+			return nil, status.Errorf(codes.Internal, "can't break association on source site %s", err.Error())
+		}
+	}
+
 	err = isiConfig.isiSvc.DeleteVolume(ctx, isiPath, "")
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
# Description
Break association when deleting protection group, this allows to fix a bug with deletion of volume group for replication that happens when using `delete` RG retention policy 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/307 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

