### PR TITLE
Repl bugfix

### DIFF
--- a/service/replication.go
+++ b/service/replication.go
@@ -673,7 +673,7 @@ func reprotect(ctx context.Context, localIsiConfig *IsilonClusterConfig, remoteI
 		return status.Errorf(codes.Internal, "can't find remote replication policy, unexpected error %s", err.Error())
 	}
 	if s1TP.FailoverFailbackState == "writes_disabled" {
-		return status.Errorf(codes.Internal, "unable to perform reprotect with writes disabled, perform reprotect on another side")
+		return status.Errorf(codes.InvalidArgument, "unable to perform reprotect with writes disabled, perform reprotect on another side")
 	}
 
 	remotePolicy, err := remoteIsiConfig.isiSvc.client.GetPolicyByName(ctx, ppName)

--- a/service/replication.go
+++ b/service/replication.go
@@ -666,6 +666,15 @@ func reprotect(ctx context.Context, localIsiConfig *IsilonClusterConfig, remoteI
 	// this assumes we run reprotect_local action hence we use localIsiConfig
 
 	ppName := strings.ReplaceAll(vgName, ".", "-")
+	// if local allowed writes -- do not do failover
+
+	s1TP, err := localIsiConfig.isiSvc.client.GetTargetPolicyByName(ctx, ppName)
+	if err != nil {
+		return status.Errorf(codes.Internal, "can't find remote replication policy, unexpected error %s", err.Error())
+	}
+	if s1TP.FailoverFailbackState == "writes_disabled" {
+		return status.Errorf(codes.Internal, "unable to perform reprotect with writes disabled, perform reprotect on another side")
+	}
 
 	remotePolicy, err := remoteIsiConfig.isiSvc.client.GetPolicyByName(ctx, ppName)
 	if err != nil {


### PR DESCRIPTION
# Description
Running reprotect on local side will put your RG in UNKNOWN state, you can recover from this state but you will need to run another failover action from target side. (repctl won't allow you to do that action saying "error executing failover to source site" so you would need to edit manually via kubectl edit)

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # [308](https://github.com/dell/csm/issues/308)

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
manually e2e
