### PR TITLE
Replication sidecar version update + small unit test correction

### DIFF
--- a/helm/csi-isilon/values.yaml
+++ b/helm/csi-isilon/values.yaml
@@ -123,7 +123,7 @@ controller:
     # image: Image to use for dell-csi-replicator. This shouldn't be changed
     # Allowed values: string
     # Default value: None
-    image: dellemc/dell-csi-replicator:v1.2.0
+    image: dellemc/dell-csi-replicator:v1.3.0
 
     # replicationContextPrefix: prefix to use for naming of resources created by replication feature
     # Allowed values: string

--- a/service/features/replication.feature
+++ b/service/features/replication.feature
@@ -204,12 +204,6 @@ Feature: Isilon CSI interface
       | induced             | errormsg                              |
       | "UpdatePolicyError" | "suspend: can't disable local policy" |
 
-  Scenario: Execute action reprotect
-    Given a Isilon service
-    And I enable quota
-    When I call ReprotectExecuteAction
-    Then a valid ExecuteActionResponse is returned
-
   Scenario: Execute action sync
     Given a Isilon service
     And I enable quota
@@ -269,9 +263,10 @@ Feature: Isilon CSI interface
       | induced                        | errormsg                                                    |
       | "GetPolicyInternalError"       | "reprotect: can't get policy"                               |
       | "GetPolicyNotFoundError"       | "reprotect: can't create protection policy EOF"             |
-      | "GetTargetPolicyInternalError" | "reprotect: couldn't get target policy"                     |
+      | "GetTargetPolicyInternalError" | "reprotect: can't find remote replication policy"           |
       | "GetPolicyError"               | "reprotect: can't ensure protection policy exists "         |
       | "Reprotect"                    | "reprotect: policy couldn't reach enabled condition on TGT" |
+      | "ReprotectTP"                  | "none" |
 
   Scenario Outline: Execute action
     Given a Isilon service


### PR DESCRIPTION
# Description
- Changed non error case for reprotect in replication unit tests
- Changed replication sidecar image version to 1.3.0

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csi-powerscale/pull/81 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken
