### PR TITLE
Add leeway to check tolerance

### DIFF
--- a/service/controllerNodeToArrayConnectivity.go
+++ b/service/controllerNodeToArrayConnectivity.go
@@ -3,7 +3,6 @@ package service
 import (
 	"context"
 	"encoding/json"
-	log "github.com/sirupsen/logrus"
 	"io/ioutil"
 	"net/http"
 	"time"
@@ -14,6 +13,7 @@ const timeout = time.Second * 5
 
 //queryStatus make API call to the specified url to retrieve connection status
 func (s *service) queryArrayStatus(ctx context.Context, url string) (bool, error) {
+	ctx, log, _ := GetRunIDLog(ctx)
 	defer func() {
 		if err := recover(); err != nil {
 			log.Println("panic occurred in queryStatus:", err)
@@ -64,7 +64,8 @@ func (s *service) queryArrayStatus(ctx context.Context, url string) (bool, error
 		return false, nil
 	}
 	log.Debugf("last connectivity was  %d sec back, tolerance is %d sec", timeDiff, tolerance)
-	if timeDiff < tolerance {
+	//give 2s leeway for tolerance check
+	if timeDiff <= tolerance+2 {
 		return true, nil
 	}
 	return false, nil


### PR DESCRIPTION
# Description
It is possible for the tolerance and the timediff of connectivity check to be the same.
Adding a leeway of 2 sec for the same.

# GitHub Issues
https://github.com/dell/csm/issues/262

| GitHub Issue # |
| -------------- |
https://github.com/dell/csm/issues/262

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested that connectivity check is run successfully

