### PR TITLE
Updating default node selector value from master to control-plane to support k8s 1.24

### DIFF
--- a/helm/csi-isilon/values.yaml
+++ b/helm/csi-isilon/values.yaml
@@ -176,14 +176,14 @@ controller:
   # Allowed values: map of key-value pairs
   # Default value: None
   # Examples:
-  #   node-role.kubernetes.io/master: ""
+  #   node-role.kubernetes.io/control-plane: ""
   nodeSelector:
-  #  node-role.kubernetes.io/master: ""
+  #  node-role.kubernetes.io/control-plane: ""
 
   # tolerations: Define tolerations for the controller deployment, if required.
   # Default value: None
   tolerations:
-  #  - key: "node-role.kubernetes.io/master"
+  #  - key: "node-role.kubernetes.io/control-plane"
   #    operator: "Equal"
   #    value: "true"
   #    effect: "NoSchedule"
@@ -197,9 +197,9 @@ node:
   # Allowed values: map of key-value pairs
   # Default value: None
   # Examples:
-  #   node-role.kubernetes.io/master: ""
+  #   node-role.kubernetes.io/control-plane: ""
   nodeSelector:
-  #  node-role.kubernetes.io/master: ""
+  #  node-role.kubernetes.io/control-plane: ""
 
   # tolerations: Define tolerations for the node daemonset, if required.
   # Default value: None


### PR DESCRIPTION
# Description
Updating default node selector value from master to control-plane.


# GitHub Issues
https://github.com/dell/csm/issues/319

| GitHub Issue # |
| -------------- |
https://github.com/dell/csm/issues/319

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
