### PR TITLE
Default value for pathLimit changed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/dell/dell-csi-extensions/podmon v0.1.0
 	github.com/dell/dell-csi-extensions/replication v1.1.0
 	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.1.0
-	github.com/dell/gocsi v1.5.2-0.20220523053849-2bf3d53bf42f
+	github.com/dell/gocsi v1.5.2-0.20220525142554-48ff29a07e1e
 	github.com/dell/gofsutil v1.8.0
 	github.com/dell/goisilon v1.7.1-0.20220523151745-c7279cad3de8
 	github.com/fsnotify/fsnotify v1.4.9

--- a/go.sum
+++ b/go.sum
@@ -119,6 +119,8 @@ github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.1.0 h1:PlZsSnl/UfgAfd
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.1.0/go.mod h1:jfpjS6YywYdApbmkRYHSeqYhKVOJZMSH9SGbb4ig2qI=
 github.com/dell/gocsi v1.5.2-0.20220523053849-2bf3d53bf42f h1:cPR/93yvvyyYjUbIoVoa59oGNPcKRmvQQ7jAiWztJH8=
 github.com/dell/gocsi v1.5.2-0.20220523053849-2bf3d53bf42f/go.mod h1:cGd8QtRfAWgyyZcf59VMADoXLfGNkJuhUqSdyW/XNQ0=
+github.com/dell/gocsi v1.5.2-0.20220525142554-48ff29a07e1e h1:OtRHmydGV0pSStKc0cANn2PrTsf5DzJEpE76z3M2WWc=
+github.com/dell/gocsi v1.5.2-0.20220525142554-48ff29a07e1e/go.mod h1:+ihwgNYeFTv69Ym2X2Ij1idK72JYoNR8CeiWYJrrbho=
 github.com/dell/gofsutil v1.8.0 h1:YqsTQF3n6GAlCLVjxLkD6GmHG4mKX2SLpD64mpsAdY8=
 github.com/dell/gofsutil v1.8.0/go.mod h1:oWLiV7FmBurEie3An11SNqQ1ReyOiqjSZaXDRhm7tMc=
 github.com/dell/goisilon v1.7.1-0.20220523151745-c7279cad3de8 h1:tWtY0AxB+w8tnaoeQyKq893WFEb0hgGQ4rZBfcsZs54=

--- a/helm/csi-isilon/values.yaml
+++ b/helm/csi-isilon/values.yaml
@@ -76,9 +76,9 @@ fsGroupPolicy: ReadWriteOnceWithFSType
 podmonAPIPort: 8083
 
 # maxPathLen: this parameter is used for setting the maximum Path length for the given volume.
-# Default value: 128
-# Examples: 128, 256
-maxPathLen: 128
+# Default value: 192
+# Examples: 192, 256
+maxPathLen: 192
 
 # controller: configure controller pod specific parameters
 controller:


### PR DESCRIPTION
# Description
This PR is used to set the default value for maxPathLimit parameter

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/263|
|https://github.com/dell/csm/issues/298|

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [X] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- Set the negative value(-10) in the values.yaml file of csi-powerscale and verified that the maxPathLimit parameter was taking the default value in the driver logs
time="2022-05-25T13:39:10Z" level=debug msg="PathLimit set to negative value, using the default value for pathLimit: 192"
- Set the maxPathLimit to 30 in the values.yaml file and verified that the maxPathLimit parameter was taking the value set in the file in the driver logs.
time="2022-05-25T13:41:34Z" level=debug msg="PathLimit: 30"
