### PR TITLE
Get gosec to pass again

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -16,15 +16,15 @@ jobs:
         with:
           directories: ./...
   go_security_scan:
-    name: Go security
+    name: Run gosec
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the code
         uses: actions/checkout@v2
-      - name: Run Go Security
-        uses: securego/gosec@master
+      - name: Run gosec to check for security vulnerabilities
+        uses: dell/common-github-actions/gosec-runner@main
         with:
-          args: ./...
+          directories: "./..."
   malware_security_scan:
     name: Malware Scanner
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description
Use the gosec action from common-github-actions to get gosec passing again -- see this PR for further details: https://github.com/dell/common-github-actions/pull/63

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Ran actions, confirmed passing