### PR TITLE
Add UT for ROvolume from snapshot with RCE true

### DIFF
--- a/service/features/service.feature
+++ b/service/features/service.feature
@@ -481,6 +481,6 @@ Feature: Isilon CSI interface
     Given a Isilon service
     And I set RootClientEnabled to "true"
     And I call CreateVolumeFromSnapshotMultiReader "43" "snapVol1"
-    And I call ControllerPublishVolume on Snapshot with name "snapVol1=_=_=43=_=_=System" and access type "multiple-reader" to "vpi7125=#=#=vpi7125.a.b.com=#=#=1.1.1.1"
+    And I call ControllerPublishVolume on Snapshot with name "snapVol1=_=_=43=_=_=System" and access type "multiple-reader" to "vpi7125=#=#=vpi7125.a.b.com=#=#=1.1.1.1" and path "/ifs/.snapshot/snapshot-snappath"
     Then a valid ControllerPublishVolumeResponse is returned
     Then a valid CreateVolumeResponse is returned

--- a/service/features/service.feature
+++ b/service/features/service.feature
@@ -477,3 +477,10 @@ Feature: Isilon CSI interface
        | "controller" | "true" | "7089" | "90" |
        | "controller" | "true" | "0" | "0" |
 
+  Scenario: Create RO volume from snapshot With RootClient Enabled
+    Given a Isilon service
+    And I set RootClientEnabled to "true"
+    And I call CreateVolumeFromSnapshotMultiReader "43" "snapVol1"
+    And I call ControllerPublishVolume on Snapshot with name "snapVol1=_=_=43=_=_=System" and access type "multiple-reader" to "vpi7125=#=#=vpi7125.a.b.com=#=#=1.1.1.1"
+    Then a valid ControllerPublishVolumeResponse is returned
+    Then a valid CreateVolumeResponse is returned

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -412,7 +412,7 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^I set podmon enable to "([^"]*)"$`, f.iSetPodmonEnable)
 	s.Step(`^I set API port to "([^"]*)"$`, f.iSetAPIPort)
 	s.Step(`^I set polling freq to "([^"]*)"$`, f.iSetPollingFeqTo)
-	s.Step(`^I call ControllerPublishVolume on Snapshot with name "([^"]*)" and access type "([^"]*)" to "([^"]*)"$`, f.iCallControllerPublishVolumeOnSnapshot)
+	s.Step(`^I call ControllerPublishVolume on Snapshot with name "([^"]*)" and access type "([^"]*)" to "([^"]*)" and path "([^"]*)"$`, f.iCallControllerPublishVolumeOnSnapshot)
 
 }
 
@@ -3345,13 +3345,13 @@ func (f *feature) aValidDeleteSnapshotResponseIsReturned() error {
 	return nil
 }
 
-func (f *feature) iCallControllerPublishVolumeOnSnapshot(volID string, accessMode string, nodeID string) error {
+func (f *feature) iCallControllerPublishVolumeOnSnapshot(volID, accessMode, nodeID, path string) error {
 	log.Printf("iCallControllerPublishVolume called with %s and %s", accessMode, nodeID)
 	header := metadata.New(map[string]string{"csi.requestid": "1"})
 	ctx := metadata.NewIncomingContext(context.Background(), header)
 	req := f.publishVolumeRequest
 	if f.publishVolumeRequest == nil {
-		req = f.getControllerPublishVolumeRequestOnSnapshot(accessMode, nodeID)
+		req = f.getControllerPublishVolumeRequestOnSnapshot(accessMode, nodeID, path)
 		f.publishVolumeRequest = req
 	}
 
@@ -3369,7 +3369,7 @@ func (f *feature) iCallControllerPublishVolumeOnSnapshot(volID string, accessMod
 	return nil
 }
 
-func (f *feature) getControllerPublishVolumeRequestOnSnapshot(accessType, nodeID string) *csi.ControllerPublishVolumeRequest {
+func (f *feature) getControllerPublishVolumeRequestOnSnapshot(accessType, nodeID, path string) *csi.ControllerPublishVolumeRequest {
 	capability := new(csi.VolumeCapability)
 
 	mountVolume := new(csi.VolumeCapability_MountVolume)
@@ -3404,7 +3404,7 @@ func (f *feature) getControllerPublishVolumeRequestOnSnapshot(accessType, nodeID
 	if f.rootClientEnabled != "" {
 		attributes[RootClientEnabledParam] = f.rootClientEnabled
 	}
-	attributes[ExportPathParam] = "/ifs/.snapshot/snapshot-54820ad0-b127-412b-8286-20d5275d2161"
+	attributes[ExportPathParam] = path
 	//ExportPathParam
 	req.VolumeContext = attributes
 	return req


### PR DESCRIPTION
# Description
Add UT to test the scenario of creating a RO PVC from snapshot with RootClientEnabled set to true and then mount that volume.
Overall coverage is 77.7%, and controller.go coverage is now 76.3%

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
https://github.com/dell/csm/issues/362

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- Ran all UTs.
