### PR TITLE
Resolved bug that required SC/secret to match IsiPaths

### DIFF
--- a/service/replication.go
+++ b/service/replication.go
@@ -3,17 +3,17 @@ package service
 import (
 	"context"
 	"fmt"
-	"github.com/dell/csi-isilon/common/constants"
-	v11 "github.com/dell/goisilon/api/v11"
-	v2 "github.com/dell/goisilon/api/v2"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/dell/csi-isilon/common/constants"
 	"github.com/dell/csi-isilon/common/utils"
 	csiext "github.com/dell/dell-csi-extensions/replication"
 	isi "github.com/dell/goisilon"
 	isiApi "github.com/dell/goisilon/api"
+	v11 "github.com/dell/goisilon/api/v11"
+	v2 "github.com/dell/goisilon/api/v2"
 	"github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -76,7 +76,14 @@ func (s *service) CreateRemoteVolume(ctx context.Context,
 	exportPath := (*export.Paths)[0]
 
 	isiPath := utils.GetIsiPathFromExportPath(exportPath)
-	ppName := strings.ReplaceAll(strings.ReplaceAll(strings.TrimPrefix(isiPath, isiConfig.IsiPath), "/", ""), ".", "-")
+	pathToStrip := ""
+	storageClassIsi, ok := req.Parameters["IsiPath"]
+	if !ok {
+		pathToStrip = isiConfig.IsiPath
+	} else {
+		pathToStrip = storageClassIsi
+	}
+	ppName := strings.ReplaceAll(strings.ReplaceAll(strings.TrimPrefix(isiPath, pathToStrip), "/", ""), ".", "-")
 
 	err = isiConfig.isiSvc.client.SyncPolicy(ctx, ppName)
 	if err != nil {


### PR DESCRIPTION
# Description
A minor change was made in the replication.go to address the below issue. Now, the protection policy (SyncIQ policy) name is correctly generated when storage IsiPath differs from secret IsiPath. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| ------------- |
| [dell/csm#508](https://github.com/dell/csm/issues/508) |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- Driver installation was performed on both source and target k8s cluster.
- SCs were created with IsiPaths that do not match the one used in secret YAML. Two of them, one in a subdirectory of the secret's IsiPath and one in an unrelated directory.
- Replicated PVs were successfully created on these IsiPaths. 
