### PR TITLE
Fix replicated PV having incorrect AzServiceIP value

### DIFF
--- a/samples/storageclass/isilon-replication.yaml
+++ b/samples/storageclass/isilon-replication.yaml
@@ -66,14 +66,6 @@ parameters:
   # Default value: endpoint of the remote cluster ClusterName
   # replication.storage.dell.com/remoteAzServiceIP: 192.168.2.1
 
-  # replication.storage.dell.com/remoteIsiPath: The base path for the volumes to be created on the remote PowerScale cluster.
-  # Ensure that this path exists on the remote PowerScale cluster.
-  # Allowed values: unix absolute path
-  # Optional: true
-  # Default value: value specified in values.yaml for isiPath
-  # Examples: /ifs/data/csi, /ifs/engineering
-  replication.storage.dell.com/remoteIsiPath: /ifs/data/csi
-
   # replication.storage.dell.com/remoteRootClientEnabled: When a PVC is being created, this parameter determines, when a node mounts the PVC,
   # whether to add the remote k8s node to the "Root clients" field or "Clients" field of the NFS export.
   # Allowed values:

--- a/samples/storageclass/isilon-replication.yaml
+++ b/samples/storageclass/isilon-replication.yaml
@@ -55,6 +55,34 @@ parameters:
   # Default value: None
   replication.storage.dell.com/volumeGroupPrefix: "csi"
 
+  # replication.storage.dell.com/remoteAccessZone: name of the access zone a remote volume can be created in
+  # Optional: true
+  # Default value: default value specified in values.yaml
+  # Examples: System, zone1
+  replication.storage.dell.com/remoteAccessZone: System
+
+  # replication.storage.dell.com/remoteAzServiceIP: AccessZone groupnet service IP. Update AzServiceIP if different than remote cluster endpoint.
+  # Optional: true
+  # Default value: endpoint of the remote cluster ClusterName
+  # replication.storage.dell.com/remoteAzServiceIP: 192.168.2.1
+
+  # replication.storage.dell.com/remoteIsiPath: The base path for the volumes to be created on the remote PowerScale cluster.
+  # Ensure that this path exists on the remote PowerScale cluster.
+  # Allowed values: unix absolute path
+  # Optional: true
+  # Default value: value specified in values.yaml for isiPath
+  # Examples: /ifs/data/csi, /ifs/engineering
+  replication.storage.dell.com/remoteIsiPath: /ifs/data/csi
+
+  # replication.storage.dell.com/remoteRootClientEnabled: When a PVC is being created, this parameter determines, when a node mounts the PVC,
+  # whether to add the remote k8s node to the "Root clients" field or "Clients" field of the NFS export.
+  # Allowed values:
+  #   "true": adds remote k8s node to the "Root clients" field of the NFS export
+  #   "false": adds remote k8s node to the "Clients" field of the NFS export
+  # Optional: true
+  # Default value: "false"
+  replication.storage.dell.com/remoteRootClientEnabled: "false"
+
   # The name of the access zone a volume can be created in
   # Optional: true
   # Default value: default value specified in values.yaml

--- a/service/controller.go
+++ b/service/controller.go
@@ -76,6 +76,14 @@ const (
 	KeyReplicationVGPrefix = "volumeGroupPrefix"
 	// KeyReplicationRemoteSystem represents key for replication remote system
 	KeyReplicationRemoteSystem = "remoteSystem"
+	// KeyReplicationVGPrefix represents key for replication remote access zone
+	KeyReplicationRemoteAccessZone = "remoteAccessZone"
+	// KeyReplicationVGPrefix represents key for replication remote AzServiceIP
+	KeyReplicationRemoteAzServiceIP = "remoteAzServiceIP"
+	// KeyReplicationVGPrefix represents key for replication remote Isipath
+	KeyReplicationRemoteIsiPath = "remoteIsiPath"
+	// KeyReplicationVGPrefix represents key for replication remote root client enabled
+	KeyReplicationRemoteRootClientEnabled = "remoteRootClientEnabled"
 	// KeyReplicationIgnoreNamespaces represents key for replication ignore namespaces
 	KeyReplicationIgnoreNamespaces = "ignoreNamespaces"
 	// KeyCSIPVCNamespace represents key for csi pvc namespace

--- a/service/controller.go
+++ b/service/controller.go
@@ -76,13 +76,11 @@ const (
 	KeyReplicationVGPrefix = "volumeGroupPrefix"
 	// KeyReplicationRemoteSystem represents key for replication remote system
 	KeyReplicationRemoteSystem = "remoteSystem"
-	// KeyReplicationVGPrefix represents key for replication remote access zone
+	// KeyReplicationRemoteAccessZone represents key for replication remote access zone
 	KeyReplicationRemoteAccessZone = "remoteAccessZone"
-	// KeyReplicationVGPrefix represents key for replication remote AzServiceIP
+	// KeyReplicationRemoteAzServiceIP represents key for replication remote AzServiceIP
 	KeyReplicationRemoteAzServiceIP = "remoteAzServiceIP"
-	// KeyReplicationVGPrefix represents key for replication remote Isipath
-	KeyReplicationRemoteIsiPath = "remoteIsiPath"
-	// KeyReplicationVGPrefix represents key for replication remote root client enabled
+	// KeyReplicationRemoteRootClientEnabled represents key for replication remote root client enabled
 	KeyReplicationRemoteRootClientEnabled = "remoteRootClientEnabled"
 	// KeyReplicationIgnoreNamespaces represents key for replication ignore namespaces
 	KeyReplicationIgnoreNamespaces = "ignoreNamespaces"

--- a/service/replication.go
+++ b/service/replication.go
@@ -133,9 +133,9 @@ func (s *service) CreateRemoteVolume(ctx context.Context,
 	}
 
 	remoteVolume := getRemoteCSIVolume(ctx, remoteExportID, volName, accessZone, volumeSize, remoteClusterName)
-	azServiceIp, ok := req.Parameters["AzServiceIP"]
+	azServiceIP, ok := req.Parameters["AzServiceIP"]
 	if !ok {
-		azServiceIp = remoteIsiConfig.Endpoint
+		azServiceIP = remoteIsiConfig.Endpoint
 	}
 	volumeContext := map[string]string{
 		"Path":              exportPath,
@@ -143,7 +143,7 @@ func (s *service) CreateRemoteVolume(ctx context.Context,
 		"ID":                strconv.Itoa(remoteExportID),
 		"Name":              volName,
 		"ClusterName":       remoteClusterName,
-		"AzServiceIP":       azServiceIp,
+		"AzServiceIP":       azServiceIP,
 		"RootClientEnabled": req.Parameters["RootClientEnabled"],
 	}
 

--- a/service/replication.go
+++ b/service/replication.go
@@ -85,8 +85,18 @@ func (s *service) CreateRemoteVolume(ctx context.Context,
 	}
 	volumeSize := isiConfig.isiSvc.GetVolumeSize(ctx, isiPath, volName)
 	log.Info("Volume size got: ", volumeSize)
+
+	remoteAccessZone, ok := req.Parameters[s.WithRP(KeyReplicationRemoteAccessZone)]
+	if !ok {
+		remoteAccessZone = accessZone
+	}
+	remoteIsiPath, ok := req.Parameters[s.WithRP(KeyReplicationRemoteIsiPath)]
+	if !ok {
+		remoteIsiPath = isiPath
+	}
+
 	// Check if export exists
-	remoteExport, err := remoteIsiConfig.isiSvc.GetExportWithPathAndZone(ctx, exportPath, accessZone)
+	remoteExport, err := remoteIsiConfig.isiSvc.GetExportWithPathAndZone(ctx, exportPath, remoteAccessZone)
 	if err != nil {
 		log.Info("Remote export error")
 		return nil, status.Error(codes.NotFound, err.Error())
@@ -110,13 +120,13 @@ func (s *service) CreateRemoteVolume(ctx context.Context,
 		} else {
 			quotaID = quota.Id
 		}
-		if remoteExportID, err = remoteIsiConfig.isiSvc.ExportVolumeWithZone(ctx, isiPath, volName, accessZone, utils.GetQuotaIDWithCSITag(quotaID)); err == nil && remoteExportID != 0 {
+		if remoteExportID, err = remoteIsiConfig.isiSvc.ExportVolumeWithZone(ctx, remoteIsiPath, volName, remoteAccessZone, utils.GetQuotaIDWithCSITag(quotaID)); err == nil && remoteExportID != 0 {
 			// get the export and retry if not found to ensure the export has been created
 			for i := 0; i < MaxRetries; i++ {
-				if export, _ := remoteIsiConfig.isiSvc.GetExportByIDWithZone(ctx, remoteExportID, accessZone); export != nil {
+				if export, _ := remoteIsiConfig.isiSvc.GetExportByIDWithZone(ctx, remoteExportID, remoteAccessZone); export != nil {
 					// Add dummy localhost entry for pvc security
-					if !remoteIsiConfig.isiSvc.IsHostAlreadyAdded(ctx, remoteExportID, accessZone, utils.DummyHostNodeID) {
-						err = remoteIsiConfig.isiSvc.AddExportClientNetworkIdentifierByIDWithZone(ctx, remoteClusterName, remoteExportID, accessZone, utils.DummyHostNodeID, remoteIsiConfig.isiSvc.AddExportClientByIDWithZone)
+					if !remoteIsiConfig.isiSvc.IsHostAlreadyAdded(ctx, remoteExportID, remoteAccessZone, utils.DummyHostNodeID) {
+						err = remoteIsiConfig.isiSvc.AddExportClientNetworkIdentifierByIDWithZone(ctx, remoteClusterName, remoteExportID, remoteAccessZone, utils.DummyHostNodeID, remoteIsiConfig.isiSvc.AddExportClientByIDWithZone)
 						if err != nil {
 							log.Debugf("Error while adding dummy localhost entry to export '%d'", remoteExportID)
 						}
@@ -132,19 +142,19 @@ func (s *service) CreateRemoteVolume(ctx context.Context,
 		remoteExportID = remoteExport.ID
 	}
 
-	remoteVolume := getRemoteCSIVolume(ctx, remoteExportID, volName, accessZone, volumeSize, remoteClusterName)
-	azServiceIP, ok := req.Parameters["AzServiceIP"]
+	remoteVolume := getRemoteCSIVolume(ctx, remoteExportID, volName, remoteAccessZone, volumeSize, remoteClusterName)
+	remoteAzServiceIP, ok := req.Parameters[s.WithRP(KeyReplicationRemoteAzServiceIP)]
 	if !ok {
-		azServiceIP = remoteIsiConfig.Endpoint
+		remoteAzServiceIP = remoteIsiConfig.Endpoint
 	}
 	volumeContext := map[string]string{
 		"Path":              exportPath,
-		"AccessZone":        accessZone,
+		"AccessZone":        remoteAccessZone,
 		"ID":                strconv.Itoa(remoteExportID),
 		"Name":              volName,
 		"ClusterName":       remoteClusterName,
-		"AzServiceIP":       azServiceIP,
-		"RootClientEnabled": req.Parameters["RootClientEnabled"],
+		"AzServiceIP":       remoteAzServiceIP,
+		"RootClientEnabled": req.Parameters[s.WithRP(KeyReplicationRemoteRootClientEnabled)],
 	}
 
 	log.Println(volumeContext)

--- a/service/replication.go
+++ b/service/replication.go
@@ -3,12 +3,13 @@ package service
 import (
 	"context"
 	"fmt"
-	"github.com/dell/csi-isilon/common/constants"
-	v11 "github.com/dell/goisilon/api/v11"
-	v2 "github.com/dell/goisilon/api/v2"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/dell/csi-isilon/common/constants"
+	v11 "github.com/dell/goisilon/api/v11"
+	v2 "github.com/dell/goisilon/api/v2"
 
 	"github.com/dell/csi-isilon/common/utils"
 	csiext "github.com/dell/dell-csi-extensions/replication"
@@ -132,13 +133,17 @@ func (s *service) CreateRemoteVolume(ctx context.Context,
 	}
 
 	remoteVolume := getRemoteCSIVolume(ctx, remoteExportID, volName, accessZone, volumeSize, remoteClusterName)
+	azServiceIp, ok := req.Parameters["AzServiceIP"]
+	if !ok {
+		azServiceIp = remoteIsiConfig.Endpoint
+	}
 	volumeContext := map[string]string{
 		"Path":              exportPath,
 		"AccessZone":        accessZone,
 		"ID":                strconv.Itoa(remoteExportID),
 		"Name":              volName,
 		"ClusterName":       remoteClusterName,
-		"AzServiceIP":       remoteIsiConfig.Endpoint,
+		"AzServiceIP":       azServiceIp,
 		"RootClientEnabled": req.Parameters["RootClientEnabled"],
 	}
 

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -3300,7 +3300,6 @@ func getCreatevolumeReplicationEnabled(s *service) *csi.CreateVolumeRequest {
 	parameters[s.WithRP(KeyReplicationVGPrefix)] = "volumeGroupPrefix"
 	parameters[s.WithRP(KeyReplicationRemoteAccessZone)] = "remoteAccessZone"
 	parameters[s.WithRP(KeyReplicationRemoteAzServiceIP)] = "remoteAzServiceIP"
-	parameters[s.WithRP(KeyReplicationRemoteIsiPath)] = "remoteIsiPath"
 	parameters[s.WithRP(KeyReplicationRemoteRootClientEnabled)] = "remoteRootClientEnabled"
 	parameters[s.WithRP(KeyReplicationRPO)] = "Five_Minutes"
 	parameters[s.WithRP(KeyReplicationRemoteSystem)] = "cluster1"

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -19,7 +19,6 @@ import (
 	context2 "context"
 	"errors"
 	"fmt"
-	"github.com/dell/csi-isilon/service/mock/k8s"
 	"log"
 	"net"
 	"net/http/httptest"
@@ -28,6 +27,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/dell/csi-isilon/service/mock/k8s"
 
 	"github.com/dell/csi-isilon/common/utils"
 
@@ -3297,6 +3298,10 @@ func getCreatevolumeReplicationEnabled(s *service) *csi.CreateVolumeRequest {
 	parameters[IsiPathParam] = "/ifs/data/csi-isilon"
 	parameters[s.WithRP(KeyReplicationEnabled)] = "true"
 	parameters[s.WithRP(KeyReplicationVGPrefix)] = "volumeGroupPrefix"
+	parameters[s.WithRP(KeyReplicationRemoteAccessZone)] = "remoteAccessZone"
+	parameters[s.WithRP(KeyReplicationRemoteAzServiceIP)] = "remoteAzServiceIP"
+	parameters[s.WithRP(KeyReplicationRemoteIsiPath)] = "remoteIsiPath"
+	parameters[s.WithRP(KeyReplicationRemoteRootClientEnabled)] = "remoteRootClientEnabled"
 	parameters[s.WithRP(KeyReplicationRPO)] = "Five_Minutes"
 	parameters[s.WithRP(KeyReplicationRemoteSystem)] = "cluster1"
 	parameters[req.VolumeContentSource.String()] = "contentsource"


### PR DESCRIPTION
# Description
Storage class design for the PowerScale does not provide sufficient information to the driver on the source k8s cluster when creating a remote volume. With current implementation, only the target SC on the remote k8s cluster has the required information. 
I don’t think we should be retrieving the target SC from remote k8s cluster in the source side driver. So I added few replication parameters as you can see in samples/storageclass/isilon-replication.yaml. With this fix, the replicated PV is set with its own properties (AzServiceIp, access zone and rootClientEnabled).

Changes will be made in repctl tool to support this and csm-docs will be updated.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/514 |

# Checklist:

- [ x ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ x ] I have verified that new and existing unit tests pass locally with my changes
- [ x ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ x ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- When provisioned with updated storage class, I noticed that the PVs on both sides are set with their own properties (AccessZone, AzServiceIp and RootClientEnabled). Please note that I do not have a lab set up that has AzServiceIP configured. I will reach out to Florian on this.
SC and PV files with dummy AzService IP values, are attached for reference.

[sc-tgt.txt](https://github.com/dell/csi-powerscale/files/9892011/sc-tgt.txt)
[sc-src.txt](https://github.com/dell/csi-powerscale/files/9892012/sc-src.txt)
[pv-tgt.txt](https://github.com/dell/csi-powerscale/files/9892013/pv-tgt.txt)
[pv-src.txt](https://github.com/dell/csi-powerscale/files/9892014/pv-src.txt)