### PR TITLE
Bugfix artifacts after deletion

### DIFF
--- a/service/features/replication.feature
+++ b/service/features/replication.feature
@@ -118,12 +118,12 @@ Feature: Isilon CSI interface
     When I call StorageProtectionGroupDelete <volume> and <systemname> and <clustername> and <vgname>
     Then the error contains <errormsg>
     Examples:
-      | volume                                   | systemname        | clustername | vgname   | errormsg                                                           |
-      | "cluster1::/ifs/data/csi-isilon/volume1" | "systemName"      | "cluster1"  | ""       | "can't find `VolumeGroupName` parameter from PG params"            |
-      | "cluster1::/ifs/data/csi-isilon/volume1" | "wrongSystemName" | "cluster5"  | "vgname" | "Can't get systemName from PG params"                              |
-      | "cluster1::/ifs/data/csi-isilon/volume1" | "systemName"      | "cluster5"  | "vgname" | "failed to get cluster config details for clusterName: 'cluster5'" |
-      | ""                                       | "systemName"      | "cluster1"  | "vgname" | "Unable to get Volume Group"                                       |
-
+      | volume                                                | systemname        | clustername | vgname   | errormsg                                                           |
+      | "cluster1::/ifs/data/csi-isilon/volume1"              | "systemName"      | "cluster1"  | ""       | "can't find `VolumeGroupName` parameter from PG params"            |
+      | "cluster1::/ifs/data/csi-isilon/volume1"              | "wrongSystemName" | "cluster5"  | "vgname" | "Can't get systemName from PG params"                              |
+      | "cluster1::/ifs/data/csi-isilon/volume1"              | "systemName"      | "cluster5"  | "vgname" | "failed to get cluster config details for clusterName: 'cluster5'" |
+      | ""                                                    | "systemName"      | "cluster1"  | "vgname" | "Error: Can't obtain valid isiPath from PG"                        |
+      | "cluster1::/ifs/badData/csi-isilon/volumeNonexistent" | "systemName"      | "cluster1"  | "vgname" | "none"                                                             |
 
   Scenario Outline: Get storage protection group status with parameters
     Given a Isilon service

--- a/service/features/replication.feature
+++ b/service/features/replication.feature
@@ -42,15 +42,15 @@ Feature: Isilon CSI interface
     And I call CreateRemoteVolume
     Then the error contains <errormsg>
     Examples:
-      | induced                  | errormsg                     |
-      | "InstancesError"         | "none"                       |
-      | "CreateQuotaError"       | "EOF"                        |
-      | "CreateExportError"      | "EOF"                        |
-      | "GetExportInternalError" | "EOF"                        |
-      | "none"                   | "none"                       |
-      | "GetPolicyInternalError" | "failed to sync data "       |
-      | "GetExportPolicyError"   | "NotFound"                   |
-      | "autoProbeFailed"        | "auto probe is not enabled"  |
+      | induced                  | errormsg                    |
+      | "InstancesError"         | "none"                      |
+      | "CreateQuotaError"       | "EOF"                       |
+      | "CreateExportError"      | "EOF"                       |
+      | "GetExportInternalError" | "EOF"                       |
+      | "none"                   | "none"                      |
+      | "GetPolicyInternalError" | "failed to sync data "      |
+      | "GetExportPolicyError"   | "NotFound"                  |
+      | "autoProbeFailed"        | "auto probe is not enabled" |
 
   Scenario Outline: Create remote volume with different volume and export status and induce server errors
     Given a Isilon service
@@ -112,18 +112,18 @@ Feature: Isilon CSI interface
       | "volume1=_=_=43"                         | "remoteSystem" | "cannot be split into tokens"                                         |
 
   @deleteStorageProtectionGroup
-    @v1.0.0
+  @v1.0.0
   Scenario Outline: Delete storage protection group
     Given a Isilon service
     When I call StorageProtectionGroupDelete <volume> and <systemname> and <clustername>
     Then the error contains <errormsg>
     Examples:
-      | volume                                   | systemname        | clustername | errormsg                                                           |
-      | "cluster1::/ifs/data/csi-isilon/volume1" | "systemName"      | "cluster1"  | "Unable to get Volume Group '/ifs/data/csi-isilon/volume1'"        |
-      | "cluster1::/ifs/data/csi-isilon/volume1" | "wrongSystemName" | "cluster5"  | "Can't get systemName from PG params"                              |
-      | "cluster1::/ifs/data/csi-isilon/volume1" | "systemName"      | "cluster5"  | "failed to get cluster config details for clusterName: 'cluster5'" |
-      | ""                                       | "systemName"      | "cluster1"  | "Unable to get Volume Group ''"                                    |
-      | ""                                       | ""                | "cluster1"  | "Can't get systemName from PG params"                              |
+      | volume                                   | systemname        | clustername | errormsg                                                |
+      | "cluster1::/ifs/data/csi-isilon/volume1" | "systemName"      | "cluster1"  | "can't find `VolumeGroupName` parameter from PG params" |
+      | "cluster1::/ifs/data/csi-isilon/volume1" | "wrongSystemName" | "cluster5"  | "Can't get systemName from PG params"                   |
+      | "cluster1::/ifs/data/csi-isilon/volume1" | "systemName"      | "cluster5"  | "can't find `VolumeGroupName` parameter from PG params" |
+      | ""                                       | "systemName"      | "cluster1"  | "can't find `VolumeGroupName` parameter from PG params" |
+      | ""                                       | ""                | "cluster1"  | "Can't get systemName from PG params"                   |
 
   Scenario Outline: Get storage protection group status with parameters
     Given a Isilon service
@@ -146,19 +146,19 @@ Feature: Isilon CSI interface
     And I call GetStorageProtectionGroupStatus
     Then the error contains <errormsg>
     Examples:
-      | induced                        | errormsg                                           |
-      | "GetJobsInternalError"         | "querying active jobs for local or remote policy"  |
-      | "GetPolicyInternalError"       | "error while getting link state"                   |
-      | "GetTargetPolicyInternalError" | "error while getting link state"                   |
-      | "FailedStatus"                 | "none"                                             |
-      | "UnknownStatus"                | "error while getting link state"                   |
-      | "Jobs"                         | "querying active jobs for local or remote policy"  |
-      | "RunningJob"                   | "none"                                             |
-      | "GetSpgErrors"                 | "error while getting link state"                   |
-      | "GetSpgTPErrors"               | "error while getting link state"                   |
+      | induced                        | errormsg                                          |
+      | "GetJobsInternalError"         | "querying active jobs for local or remote policy" |
+      | "GetPolicyInternalError"       | "error while getting link state"                  |
+      | "GetTargetPolicyInternalError" | "error while getting link state"                  |
+      | "FailedStatus"                 | "none"                                            |
+      | "UnknownStatus"                | "error while getting link state"                  |
+      | "Jobs"                         | "querying active jobs for local or remote policy" |
+      | "RunningJob"                   | "none"                                            |
+      | "GetSpgErrors"                 | "error while getting link state"                  |
+      | "GetSpgTPErrors"               | "error while getting link state"                  |
 
   @executeAction
-    @v1.0.0
+  @v1.0.0
   Scenario Outline: Execute action
     Given a Isilon service
     When I call ExecuteAction to <systemName> to <clusterNameOne> to <clusterNameTwo> to <remoteSystemName> to <vgname> to <ppname>
@@ -178,10 +178,10 @@ Feature: Isilon CSI interface
     When I call SuspendExecuteAction
     Then the error contains <errormsg>
     Examples:
-      | induced                  | errormsg                                            |
-      | "UpdatePolicyError"      | "suspend: can't disable local policy"               |
-      | "autoProbeFailed"        | "auto probe is not enabled"                         |
-      | "GetSpgErrors"           | "suspend: policy couldn't reach disabled condition" |
+      | induced             | errormsg                                            |
+      | "UpdatePolicyError" | "suspend: can't disable local policy"               |
+      | "autoProbeFailed"   | "auto probe is not enabled"                         |
+      | "GetSpgErrors"      | "suspend: policy couldn't reach disabled condition" |
 
   Scenario Outline: Execute action sync
     Given a Isilon service
@@ -189,8 +189,8 @@ Feature: Isilon CSI interface
     When I call SyncExecuteAction
     Then the error contains <errormsg>
     Examples:
-      | induced          | errormsg                   |
-      | "GetPolicyError" | "sync: policy sync failed" |
+      | induced          | errormsg             |
+      | "GetPolicyError" | "policy sync failed" |
 
   Scenario Outline: Execute action failover
     Given a Isilon service
@@ -277,7 +277,7 @@ Feature: Isilon CSI interface
     Examples:
       | systemName   | clusterNameOne | clusterNameTwo | remoteSystemName   | vgname            | ppname                                            | errormsg                      |
       | "systemName" | "cluster1"     | "cluster1"     | "remoteSystemName" | "VolumeGroupName" | "csi-prov-test-19743d82-192-168-111-25-Fifty_Min" | "unable to parse RPO seconds" |
-  
+
   Scenario Outline: Execute bad action
     Given a Isilon service
     When I call BadExecuteAction

--- a/service/features/replication.feature
+++ b/service/features/replication.feature
@@ -115,15 +115,15 @@ Feature: Isilon CSI interface
   @v1.0.0
   Scenario Outline: Delete storage protection group
     Given a Isilon service
-    When I call StorageProtectionGroupDelete <volume> and <systemname> and <clustername>
+    When I call StorageProtectionGroupDelete <volume> and <systemname> and <clustername> and <vgname>
     Then the error contains <errormsg>
     Examples:
-      | volume                                   | systemname        | clustername | errormsg                                                |
-      | "cluster1::/ifs/data/csi-isilon/volume1" | "systemName"      | "cluster1"  | "can't find `VolumeGroupName` parameter from PG params" |
-      | "cluster1::/ifs/data/csi-isilon/volume1" | "wrongSystemName" | "cluster5"  | "Can't get systemName from PG params"                   |
-      | "cluster1::/ifs/data/csi-isilon/volume1" | "systemName"      | "cluster5"  | "can't find `VolumeGroupName` parameter from PG params" |
-      | ""                                       | "systemName"      | "cluster1"  | "can't find `VolumeGroupName` parameter from PG params" |
-      | ""                                       | ""                | "cluster1"  | "Can't get systemName from PG params"                   |
+      | volume                                   | systemname        | clustername | vgname   | errormsg                                                           |
+      | "cluster1::/ifs/data/csi-isilon/volume1" | "systemName"      | "cluster1"  | ""       | "can't find `VolumeGroupName` parameter from PG params"            |
+      | "cluster1::/ifs/data/csi-isilon/volume1" | "wrongSystemName" | "cluster5"  | "vgname" | "Can't get systemName from PG params"                              |
+      | "cluster1::/ifs/data/csi-isilon/volume1" | "systemName"      | "cluster5"  | "vgname" | "failed to get cluster config details for clusterName: 'cluster5'" |
+      | ""                                       | "systemName"      | "cluster1"  | "vgname" | "Unable to get Volume Group"                                       |
+
 
   Scenario Outline: Get storage protection group status with parameters
     Given a Isilon service

--- a/service/replication.go
+++ b/service/replication.go
@@ -947,17 +947,3 @@ func getRpoInt(vgName string) int {
 
 	return rpoInt
 }
-
-// GetIsiPath obtains the IsiPath from one of three sources, in order of priority:
-// Storage Class, Array Secret, Installation Values YAML
-/*func GetIsiPath(req *csiext.CreateRemoteVolumeRequest) string {
-	var isiPath string
-	storageClassIsi, ok := req.Parameters["IsiPath"]
-	if !ok {
-		pathToStrip = isiConfig.IsiPath
-	} else {
-		pathToStrip = storageClassIsi
-	}
-	return isiPath
-}
-*/

--- a/service/replication.go
+++ b/service/replication.go
@@ -345,9 +345,8 @@ func (s *service) DeleteStorageProtectionGroup(ctx context.Context,
 		err = isiConfig.isiSvc.client.DeletePolicy(ctx, ppName)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "Unknown error while deleting PP "+ppName, err.Error())
-		} else {
-			log.Info("Protection Policy deleted.")
 		}
+		log.Info("Protection Policy deleted.")
 	} else { //policy does not exist or was not able to be retrieved
 		if e, ok := err.(*isiApi.JSONError); ok {
 			if e.StatusCode == 404 {

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -377,7 +377,7 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^a valid CreateRemoteVolumeResponse is returned$`, f.aValidCreateRemoteVolumeResponseIsReturned)
 	s.Step(`I call CreateStorageProtectionGroup`, f.iCallCreateStorageProtectionGroup)
 	s.Step(`^a valid CreateStorageProtectionGroupResponse is returned$`, f.aValidCreateStorageProtectionGroupResponseIsReturned)
-	s.Step(`^I call StorageProtectionGroupDelete "([^"]*)" and "([^"]*)" and "([^"]*)"$`, f.iCallStorageProtectionGroupDelete)
+	s.Step(`^I call StorageProtectionGroupDelete "([^"]*)" and "([^"]*)" and "([^"]*)" and "([^"]*)"$`, f.iCallStorageProtectionGroupDelete)
 	s.Step(`^a valid DeleteStorageProtectionGroupResponse is returned$`, f.aValidDeleteStorageProtectionGroupResponseIsReturned)
 	//s.Step(`^I call DeleteStorageProtectionGroupWithParams"$`, f.iCallWithParamsDeleteStorageProtectionGroup)
 	s.Step(`^I call WithParamsCreateRemoteVolume "([^"]*)" "([^"]*)"$`, f.iCallCreateRemoteVolumeWithParams)
@@ -2710,7 +2710,7 @@ func (f *feature) aValidCreateStorageProtectionGroupResponseIsReturned() error {
 	return nil
 }
 
-func deleteStorageProtectionGroupRequest(s *service, volume, systemName, clustername string) *csiext.DeleteStorageProtectionGroupRequest {
+func deleteStorageProtectionGroupRequest(s *service, volume, systemName, clustername, vgname string) *csiext.DeleteStorageProtectionGroupRequest {
 
 	req := new(csiext.DeleteStorageProtectionGroupRequest)
 
@@ -2719,11 +2719,14 @@ func deleteStorageProtectionGroupRequest(s *service, volume, systemName, cluster
 	req.ProtectionGroupAttributes = map[string]string{
 		s.opts.replicationContextPrefix + systemName: clustername,
 	}
+	if vgname != "" {
+		req.ProtectionGroupAttributes[s.opts.replicationContextPrefix+"VolumeGroupName"] = vgname
+	}
 	return req
 }
 
-func (f *feature) iCallStorageProtectionGroupDelete(volume, systemName, clustername string) error {
-	req := deleteStorageProtectionGroupRequest(f.service, volume, systemName, clustername)
+func (f *feature) iCallStorageProtectionGroupDelete(volume, systemName, clustername, vgname string) error {
+	req := deleteStorageProtectionGroupRequest(f.service, volume, systemName, clustername, vgname)
 	f.deleteStorageProtectionGroupRequest = req
 	f.deleteStorageProtectionGroupResponse, f.err = f.service.DeleteStorageProtectionGroup(context.Background(), req)
 	if f.err != nil {


### PR DESCRIPTION
# Description
Previous IsiPath logic made it such that RGs would not properly delete when the IsiPath did not match between Storage Class and array Secret.  This created artifacts that made cleaning up after creating an RG difficult. Additional logic has also been added to prevent DL when deleting a Replication Group that may have existing PVs or user-created data inside of its replication folder. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| [523](https://github.com/dell/csm/issues/523) |

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate (80.2% -> 80.7%)
- [ ] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
Test cases have been added to the replication.feature file for new method of volume group name acquisition. 

Otherwise, manual testing has been done using 'main' branch of csm-replication for replication controller/sidecar. Manual testing verified that Storage Class IsiPath no longer needs to match Secret IsiPath. It also verified that RG deletion will fail and prevent directory removal if there is anything left in the replication directory. 

Also did thorough IsiPath priority testing, to verify that SC > Secret > values.yaml priority all works as intended. 
