### PR TITLE
Updated replication extension package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/cucumber/godog v0.10.0
 	github.com/dell/dell-csi-extensions/common v1.1.0
 	github.com/dell/dell-csi-extensions/podmon v1.1.1
-	github.com/dell/dell-csi-extensions/replication v1.2.1
+	github.com/dell/dell-csi-extensions/replication v1.2.2-0.20230112204455-8f3445ef5483
 	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.1
 	github.com/dell/gocsi v1.6.0
 	github.com/dell/gofsutil v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -113,8 +113,8 @@ github.com/dell/dell-csi-extensions/common v1.1.0 h1:BFWoXdAennOs+fFiYqsGo02AU27
 github.com/dell/dell-csi-extensions/common v1.1.0/go.mod h1:x68COjv2yqphSmGWZDPV9WcBENA9+e8v21aGFO5i3PQ=
 github.com/dell/dell-csi-extensions/podmon v1.1.1 h1:AIFHmVscJInpADaJyXMuvpHZKAhLpQhD+7dFHjHKdjI=
 github.com/dell/dell-csi-extensions/podmon v1.1.1/go.mod h1:J4VNEmXV6sz40QviNF1B+Ov+KNQmzFtJw0YNUpq6ncs=
-github.com/dell/dell-csi-extensions/replication v1.2.1 h1:dx67k7BBN/aZKgPdOgO04PNFTciChnNwIx+Cnwlgq0s=
-github.com/dell/dell-csi-extensions/replication v1.2.1/go.mod h1:FU2kzS8/29GlK9iCdS+E70cyeWun63eNP44aHwg7jW8=
+github.com/dell/dell-csi-extensions/replication v1.2.2-0.20230112204455-8f3445ef5483 h1:sVMPxFaRBk80s+gwPAtzw1mtcjefDdvv1drkoyK1/kg=
+github.com/dell/dell-csi-extensions/replication v1.2.2-0.20230112204455-8f3445ef5483/go.mod h1:FU2kzS8/29GlK9iCdS+E70cyeWun63eNP44aHwg7jW8=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.1 h1:EQAa1da2njL31ev6pJ6X4KTynKB4qpN6ZcuWYdZ58hI=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.1/go.mod h1:etLWwS1G2IqHDuArHqB0OWQvpdcztuBxopWrRE+mpk0=
 github.com/dell/gocsi v1.6.0 h1:ZmoMi17v1jK0RE0OGEivu52/RqHbOhP5cqs9SHExqa0=

--- a/helm/csi-isilon/values.yaml
+++ b/helm/csi-isilon/values.yaml
@@ -123,7 +123,7 @@ controller:
     # image: Image to use for dell-csi-replicator. This shouldn't be changed
     # Allowed values: string
     # Default value: None
-    image: dellemc/dell-csi-replicator:v1.3.0
+    image: dellemc/dell-csi-replicator:v1.4.0
 
     # replicationContextPrefix: prefix to use for naming of resources created by replication feature
     # Allowed values: string

--- a/service/controllerNodeToArrayConnectivity.go
+++ b/service/controllerNodeToArrayConnectivity.go
@@ -55,7 +55,11 @@ func (s *service) queryArrayStatus(ctx context.Context, url string) (bool, error
 		log.Errorf("failed to call API %s due to %s ", url, err.Error())
 		return false, err
 	}
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			log.Printf("Error closing HTTP response: %s", err.Error())
+		}
+	}()
 	bodyBytes, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		log.Errorf("failed to read API response due to %s ", err.Error())


### PR DESCRIPTION
# Description

- Updated replication extension package version (https://github.com/dell/dell-csi-extensions/pull/27) as the extension updated from alpha to v1 version.
- Replicator side car image is updated to v1.4.0.
- Fixed GoSec vulnerability reported on latest code.

Note: Since 1.4 replicator side care image is not officially out, please use latest or nightly tags (which will be updated when this PR merges).

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/432 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate (80.7%)
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Tested as part of https://github.com/dell/csm-replication/pull/75 https://github.com/dell/csm-replication/pull/76 replication module and isilon upgrade testing.
