### PR TITLE
[FEATURE]: Support Storage Capacity Tracking in CSI-PowerScale driver

### DIFF
--- a/helm/csi-isilon/templates/_helpers.tpl
+++ b/helm/csi-isilon/templates/_helpers.tpl
@@ -48,3 +48,14 @@ Return the appropriate sidecar images based on k8s version
     {{- end -}}
   {{- end -}}
 {{- end -}}
+
+{{/*
+Return true if storage capacity tracking is enabled and is supported based on k8s version
+*/}}
+{{- define "csi-isilon.isStorageCapacitySupported" -}}
+{{- if eq .Values.storageCapacity.enabled true -}}
+  {{- if and (eq .Capabilities.KubeVersion.Major "1") (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "24") -}}
+      {{- true -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/helm/csi-isilon/templates/controller.yaml
+++ b/helm/csi-isilon/templates/controller.yaml
@@ -103,6 +103,17 @@ rules:
     verbs: ["create", "delete", "get", "list", "watch", "update", "patch"]
   {{- end}}
   {{- end}}
+  {{- if eq (include "csi-isilon.isStorageCapacitySupported" .) "true" }}
+  - apiGroups: ["storage.k8s.io"]
+    resources: ["csistoragecapacities"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: [""]
+    resources: ["pods"]
+    verbs: ["get"]
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get"]
+  {{- end }}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -326,6 +337,9 @@ spec:
             - "--feature-gates=Topology=true"
             - "--leader-election"
             - "--extra-create-metadata"
+            - "--enable-capacity={{ (include "csi-isilon.isStorageCapacitySupported" .) | default false }}"
+            - "--capacity-ownerref-level=2"
+            - "--capacity-poll-interval={{ .Values.storageCapacity.pollInterval | default "5m" }}"
             {{- if hasKey .Values.controller "leaderElection" }}
             {{- if hasKey .Values.controller.leaderElection "leaderElectionRenewDeadline" }}
             - "--leader-election-renew-deadline={{ .Values.controller.leaderElection.leaderElectionRenewDeadline }}"
@@ -337,6 +351,15 @@ spec:
             - "--leader-election-retry-period={{ .Values.controller.leaderElection.leaderElectionRetryPeriod }}"
             {{end}}
             {{end}}
+          env:
+            - name: NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi

--- a/helm/csi-isilon/templates/csidriver.yaml
+++ b/helm/csi-isilon/templates/csidriver.yaml
@@ -5,6 +5,7 @@ metadata:
 spec:
     attachRequired: true
     podInfoOnMount: true
+    storageCapacity: {{ (include "csi-isilon.isStorageCapacitySupported" .) | default false }}
     fsGroupPolicy: {{ .Values.fsGroupPolicy }}
     volumeLifecycleModes: 
     - Persistent

--- a/helm/csi-isilon/values.yaml
+++ b/helm/csi-isilon/values.yaml
@@ -63,7 +63,7 @@ enableCustomTopology: false
 # Allowed values:
 #   ReadWriteOnceWithFSType: supports volume ownership and permissions change only if the fsType is defined
 #   and the volume's accessModes contains ReadWriteOnce.
-#   File: kubernetes may use fsGroup to change permissions and ownership of the volume 
+#   File: kubernetes may use fsGroup to change permissions and ownership of the volume
 #   to match user requested fsGroup in the pod's security policy regardless of fstype or access mode.
 #   None: volumes will be mounted with no modifications.
 # Default value: ReadWriteOnceWithFSType
@@ -127,7 +127,7 @@ controller:
 
     # replicationContextPrefix: prefix to use for naming of resources created by replication feature
     # Allowed values: string
-    # Default value: powerstore
+    # Default value: powerscale
     replicationContextPrefix: "powerscale"
 
     # replicationPrefix: prefix to prepend to storage classes parameters
@@ -273,7 +273,6 @@ node:
     # Default value: None
     enabled: false
 
-
 ## PLATFORM ATTRIBUTES
 ######################
 # endpointPort: Specify the HTTPs port number of the PowerScale OneFS API server
@@ -365,9 +364,23 @@ authorization:
   # skipCertificateValidation: certificate validation of the csm-authorization server
   # Allowed Values:
   #   "true" - TLS certificate verification will be skipped
-  #   "false" - TLS certificate will be verified 
-  # Default value: "true" 
+  #   "false" - TLS certificate will be verified
+  # Default value: "true"
   skipCertificateValidation: true
+
+# Storage Capacity Tracking
+# Note: Capacity tracking is supported in kubernetes v1.24 and above, this feature will be automatically disabled in older versions.
+storageCapacity:
+  # enabled : Enable/Disable storage capacity tracking
+  # Allowed values:
+  #   true: enable storage capacity tracking
+  #   false: disable storage capacity tracking
+  # Default value: true
+  enabled: true
+  # pollInterval : Configure how often external-provisioner polls the driver to detect changed capacity
+  # Allowed values: 1m,2m,3m,...,10m,...,60m etc
+  # Default value: 5m
+  pollInterval: 5m
 
 # Enable this feature only after contact support for additional information
 podmon:
@@ -413,15 +426,15 @@ encryption:
   # logLevel: Log level of the encryption driver.
   # Allowed values: "error", "warning", "info", "debug", "trace".
   logLevel: "error"
-  
-  # livenessPort: HTTP liveness probe port number. 
+
+  # livenessPort: HTTP liveness probe port number.
   # Leave empty to disable the liveness probe.
   # Example: 8080
   livenessPort:
 
   # ocp: Enable when running on OpenShift Container Platform with CoreOS worker nodes.
   ocp: false
-  
+
   # ocpCoreID: User ID and group ID of user core on CoreOS worker nodes.
   # Ignored when ocp is set to false.
   ocpCoreID: "1000:1000"

--- a/service/controller.go
+++ b/service/controller.go
@@ -1424,16 +1424,6 @@ func (s *service) GetCapacity(
 		return nil, err
 	}
 
-	// Optionally validate the volume capability
-	vcs := req.GetVolumeCapabilities()
-	if vcs != nil {
-		supported, reason := validateVolumeCaps(vcs, nil)
-		if !supported {
-			log.Errorf("GetVolumeCapabilities failed with error: '%s'", reason)
-			return nil, status.Errorf(codes.InvalidArgument, utils.GetMessageWithRunID(runID, reason))
-		}
-	}
-
 	//pass the key(s) to rest api
 	keyArray := []string{"ifs.bytes.avail"}
 
@@ -1447,7 +1437,7 @@ func (s *service) GetCapacity(
 	remainingCapInBytes := stat.StatsList[0].Value
 
 	return &csi.GetCapacityResponse{
-		AvailableCapacity: int64(remainingCapInBytes),
+		AvailableCapacity: remainingCapInBytes,
 	}, nil
 }
 
@@ -2005,7 +1995,7 @@ func (s *service) ControllerGetVolume(ctx context.Context,
 				PublishedNodeIds: nil,
 				VolumeCondition: &csi.VolumeCondition{
 					Abnormal: true,
-					Message:  fmt.Sprintf("unable to fetch export list"),
+					Message:  "unable to fetch export list",
 				},
 			},
 		}, nil


### PR DESCRIPTION
# Description
Support Storage Capacity Tracking feature in CSI-PowerScale driver.

Additional context
Storage Capacity Tracking feature was GA'ed in Kubernetes v1.24.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/743 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
- [ ] Ran Sanity test

Create PVC
![pvc creation SCT](https://user-images.githubusercontent.com/36687396/232698431-424127ea-9c24-4239-82a9-349c03cf0423.png)

Create Pod
![pod creation SCT](https://user-images.githubusercontent.com/36687396/232698537-668188a5-057e-4a33-acf0-37ebd3a42f52.png)

PVC Status is `bound` after pod creation
![pvc after pod creation SCT](https://user-images.githubusercontent.com/36687396/232698669-15323fb2-29a0-4e15-b8de-6e53acec4786.png)

Get csistoragecapacities: `kubectl get csistoragecapacities -n isilon`
![storage capacity SCT](https://user-images.githubusercontent.com/36687396/232698944-17061718-c0d1-4442-afe9-7085c9882f02.png)

Create PVC after setting storage capacity to 0
![creating pvc after setting storage capacity to 0](https://user-images.githubusercontent.com/36687396/232699098-3892cb1b-3a19-473c-83e3-b6d54626bf84.png)

Create pod after setting storage capacity to 0
![creating pod after storage capacity is set to 0](https://user-images.githubusercontent.com/36687396/232699254-ac94a95c-13a9-41a3-b8a7-a6d845487155.png)
Note: the status change after the polling is done again for storage capacity(5 minutes)

