### PR TITLE
Migrate from Old image registry (k8s.gcr.io) to new repo (registry.k8s.io)

### DIFF
--- a/helm/csi-isilon/templates/_helpers.tpl
+++ b/helm/csi-isilon/templates/_helpers.tpl
@@ -4,7 +4,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-isilon.attacherImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "k8s.gcr.io/sig-storage/csi-attacher:v4.2.0" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-attacher:v4.2.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -12,7 +12,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-isilon.provisionerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "k8s.gcr.io/sig-storage/csi-provisioner:v3.4.0" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-provisioner:v3.4.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -20,7 +20,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-isilon.snapshotterImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "k8s.gcr.io/sig-storage/csi-snapshotter:v6.2.1" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-snapshotter:v6.2.1" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -28,7 +28,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-isilon.resizerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "k8s.gcr.io/sig-storage/csi-resizer:v1.7.0" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-resizer:v1.7.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -36,7 +36,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-isilon.registrarImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.3" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.3" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -44,7 +44,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-isilon.healthmonitorImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "gcr.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.8.0" -}}
+      {{- print "registry.k8s.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.8.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/helm/csi-isilon/templates/_helpers.tpl
+++ b/helm/csi-isilon/templates/_helpers.tpl
@@ -44,7 +44,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-isilon.healthmonitorImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "registry.k8s.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.8.0" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.8.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
# Description
Updating Kubernetes images registry from k8s.gcr.io to registry.k8s.io

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/744|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Driver Installation

![image](https://user-images.githubusercontent.com/43825650/235865455-0fe6bfbb-1660-4e37-99c3-c306c0aaa2de.png)


- [x] Container Image References
 
**Controller POD:**
![image](https://user-images.githubusercontent.com/43825650/235865663-dc7b8d88-c139-47b6-8ae7-1c330983b129.png)

**Node POD:**
![image](https://user-images.githubusercontent.com/43825650/235866404-9df02cc9-5e6d-45a1-b5b7-abab509ad98a.png)

- [x] Cert CSI
![image](https://user-images.githubusercontent.com/43825650/235874814-be958224-f910-4b2a-9696-e2a1332e1334.png)
