### PR TITLE
Replication: Target NFS exports are not deleted even though target directories are deleted

### DIFF
--- a/service/features/replication.feature
+++ b/service/features/replication.feature
@@ -157,6 +157,30 @@ Feature: Isilon CSI interface
       | "GetSpgErrors"                 | "error while getting link state"                  |
       | "GetSpgTPErrors"               | "error while getting link state"                  |
 
+  Scenario Outline: Delete local volume with parameters
+    Given a Isilon service
+    When I call Probe
+    And I call WithParamsDeleteLocalVolume <volhandle>
+    Then the error contains <errormsg>
+    Examples:
+      | volhandle                                | errormsg                                                           |
+      | "volume1=_=_=43"                         | "cannot be split into tokens"                                      |
+      | "volume1=_=_=xx=_=_=System=_=_=cluster1" | "failed to parse volume ID"                                        |
+      | "volume1=_=_=43=_=_=System=_=_=cluster2" | "failed to get cluster config details for clusterName: 'cluster2'" |
+
+  Scenario Outline: Delete local volume with induced errors
+    Given a Isilon service
+    And I enable quota
+    When I call Probe
+    And I induce error <induced>
+    And I call DeleteLocalVolume
+    Then the error contains <errormsg>
+    Examples:
+      | induced                      | errormsg                                                                      |
+      | "GetExportByIDNotFoundError" | "none"                                                                        |
+      | "GetExportInternalError"     | "EOF"                                                                         |
+      | "none"                       | "has other clients in AccessZone System. It is not safe to delete the export" |
+
   @executeAction
   @v1.0.0
   Scenario Outline: Execute action

--- a/service/replication.go
+++ b/service/replication.go
@@ -291,13 +291,57 @@ func (s *service) CreateStorageProtectionGroup(ctx context.Context,
 }
 
 // DeleteLocalVolume deletes the backend volume on the storage array.
-// There is no use case here, because a 'sync' event will take care of backend deletion.
+// There is no need to delete volume here, because a 'sync' event will take care of backend (remote) deletion.
+// Use this call to delete the NFS export for the (remote) directory which will be left out in case of no PVC on this side.
 func (s *service) DeleteLocalVolume(ctx context.Context,
 	req *csiext.DeleteLocalVolumeRequest) (*csiext.DeleteLocalVolumeResponse, error) {
 	ctx, log, _ := GetRunIDLog(ctx)
+	volumeID := req.GetVolumeHandle()
 
-	log.Info("DeleteLocalVolume called which is a NOP for file replication.")
+	log.Infof("Deleting export for volume %s per request from remote replication controller", volumeID)
 
+	// Parse the input volume ID and fetch its components
+	volName, exportID, accessZone, clusterName, err := utils.ParseNormalizedVolumeID(ctx, volumeID)
+	if err != nil {
+		return nil, status.Error(codes.InvalidArgument, fmt.Sprintf("failed to parse volume ID '%s', error: '%s'", volumeID, err.Error()))
+	}
+
+	isiConfig, err := s.getIsilonConfig(ctx, &clusterName)
+	if err != nil {
+		log.Error("Failed to get Isilon config with error ", err.Error())
+		return nil, err
+	}
+
+	ctx, log = setClusterContext(ctx, clusterName)
+	log.Debugf("Cluster Name: %v", clusterName)
+
+	// Ideally the remote directory would be gone due to sync event but the sync may take longer if the policy has greater RPO.
+	// Check if there is a NFS export for this directory (i.e only localhost as client) and then delete the export.
+	// If there are other clients, then there is a PVC on this side whose deletion would trigger DeleteVolume() thus deleting export.
+	export, err := isiConfig.isiSvc.GetExportByIDWithZone(ctx, exportID, accessZone)
+	if err != nil {
+		if jsonError, ok := err.(*isiApi.JSONError); ok && jsonError.StatusCode == 404 {
+			log.Info("Export with ID does not exist, may have been already deleted.")
+			return &csiext.DeleteLocalVolumeResponse{}, nil
+		}
+		return nil, err
+	}
+
+	isiPath := utils.GetIsiPathFromExportPath((*export.Paths)[0])
+	if isiConfig.isiSvc.IsVolumeExistent(ctx, isiPath, "", volName) {
+		log.Debugf("Local volume %s still exists, SyncIQ job has not run yet.", volName)
+	}
+
+	clients := *export.Clients
+	if len(clients) == 1 && clients[0] == "localhost" {
+		if err := isiConfig.isiSvc.UnexportByIDWithZone(ctx, exportID, accessZone); err != nil {
+			return nil, err
+		}
+	} else {
+		return nil, fmt.Errorf("export for volume %s has other clients in AccessZone %s. It is not safe to delete the export", volName, accessZone)
+	}
+
+	log.Infof("Export for volume %s deleted successfully.", volumeID)
 	return &csiext.DeleteLocalVolumeResponse{}, nil
 }
 

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -65,6 +65,8 @@ type feature struct {
 	createVolumeRequest                     *csi.CreateVolumeRequest
 	createRemoteVolumeRequest               *csiext.CreateRemoteVolumeRequest
 	createRemoteVolumeResponse              *csiext.CreateRemoteVolumeResponse
+	deleteLocalVolumeRequest                *csiext.DeleteLocalVolumeRequest
+	deleteLocalVolumeResponse               *csiext.DeleteLocalVolumeResponse
 	createStorageProtectionGroupRequest     *csiext.CreateStorageProtectionGroupRequest
 	createStorageProtectionGroupResponse    *csiext.CreateStorageProtectionGroupResponse
 	deleteStorageProtectionGroupRequest     *csiext.DeleteStorageProtectionGroupRequest
@@ -377,9 +379,10 @@ func FeatureContext(s *godog.Suite) {
 	s.Step(`^a valid CreateStorageProtectionGroupResponse is returned$`, f.aValidCreateStorageProtectionGroupResponseIsReturned)
 	s.Step(`^I call StorageProtectionGroupDelete "([^"]*)" and "([^"]*)" and "([^"]*)" and "([^"]*)"$`, f.iCallStorageProtectionGroupDelete)
 	s.Step(`^a valid DeleteStorageProtectionGroupResponse is returned$`, f.aValidDeleteStorageProtectionGroupResponseIsReturned)
-	//s.Step(`^I call DeleteStorageProtectionGroupWithParams"$`, f.iCallWithParamsDeleteStorageProtectionGroup)
 	s.Step(`^I call WithParamsCreateRemoteVolume "([^"]*)" "([^"]*)"$`, f.iCallCreateRemoteVolumeWithParams)
 	s.Step(`^I call WithParamsCreateStorageProtectionGroup "([^"]*)" "([^"]*)"$`, f.iCallCreateStorageProtectionGroupWithParams)
+	s.Step(`^I call DeleteLocalVolume`, f.iCallDeleteLocalVolume)
+	s.Step(`^I call WithParamsDeleteLocalVolume "([^"]*)"$`, f.iCallDeleteLocalVolumeWithParams)
 	s.Step(`I call GetStorageProtectionGroupStatus`, f.iCallGetStorageProtectionGroupStatus)
 	s.Step(`^a valid GetStorageProtectionGroupStatusResponse is returned$`, f.aValidGetStorageProtectionGroupStatusResponseIsReturned)
 	s.Step(`^I call WithParamsGetStorageProtectionGroupStatus "([^"]*)" "([^"]*)" "([^"]*)" "([^"]*)" "([^"]*)" "([^"]*)"$`, f.iCallGetStorageProtectionGroupStatusWithParams)
@@ -2666,6 +2669,38 @@ func (f *feature) aValidCreateRemoteVolumeResponseIsReturned() error {
 	f.volumeIDList = append(f.volumeIDList, f.createRemoteVolumeResponse.RemoteVolume.VolumeId)
 	fmt.Printf("volume '%s'\n",
 		f.createRemoteVolumeResponse.RemoteVolume.VolumeContext["Name"])
+	return nil
+}
+
+func getDeleteLocalVolumeRequest(s *service) *csiext.DeleteLocalVolumeRequest {
+	req := new(csiext.DeleteLocalVolumeRequest)
+	req.VolumeHandle = "volume1=_=_=19=_=_=System=_=_=cluster1"
+	return req
+}
+
+func (f *feature) iCallDeleteLocalVolume() error {
+	req := getDeleteLocalVolumeRequest(f.service)
+	f.deleteLocalVolumeRequest = req
+	f.deleteLocalVolumeResponse, f.err = f.service.DeleteLocalVolume(context.Background(), req)
+	if f.err != nil {
+		log.Printf("DeleteLocalVolume call failed: %s\n", f.err.Error())
+	}
+	return nil
+}
+
+func getDeleteLocalVolumeRequestWithParams(s *service, volhandle string) *csiext.DeleteLocalVolumeRequest {
+	req := new(csiext.DeleteLocalVolumeRequest)
+	req.VolumeHandle = volhandle
+	return req
+}
+
+func (f *feature) iCallDeleteLocalVolumeWithParams(volhandle string) error {
+	req := getDeleteLocalVolumeRequestWithParams(f.service, volhandle)
+	f.deleteLocalVolumeRequest = req
+	f.deleteLocalVolumeResponse, f.err = f.service.DeleteLocalVolume(context.Background(), req)
+	if f.err != nil {
+		log.Printf("DeleteLocalVolume call failed: %s\n", f.err.Error())
+	}
 	return nil
 }
 


### PR DESCRIPTION
# Description

1. Delete the NFS export for the target side PV/directory. Made use of DeleteLocalVolume replication call. This is needed if target PVs are not consumed by PVC/Pod.
2. During CreateRemoteVolume() call, break the for loop when it succeeds (10 sec performance improvement for each PV creation).


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/782 |
| https://github.com/dell/csm/issues/783 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes (_1 test currently fails on main branch_)
- [x] I have not allowed coverage numbers to degenerate (79.6%)
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Verified the target side driver log and target PowerScale cluster that the NFS export for target directory is deleted.
Tested the variations of target PV with and without PVC/Pod on its side.
