### PR TITLE
ubi image updated to micro

### DIFF
--- a/Dockerfile.podman
+++ b/Dockerfile.podman
@@ -1,4 +1,4 @@
-# Copyright © 2021-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2021-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -26,17 +26,7 @@ RUN CGO_ENABLED=0 \
 
 # Stage to build the driver image
 FROM $BASEIMAGE AS driver
-# install necessary packages
-# alphabetical order for easier maintenance
-RUN microdnf update -y && \
-        microdnf install -y \
-        e4fsprogs \
-        libaio \
-        libuuid \
-        nfs-utils \
-        numactl \
-        xfsprogs && \
-    microdnf clean all
+
 # copy in the driver
 COPY --from=builder /go/src/csi-isilon /
 ENTRYPOINT ["/csi-isilon"]

--- a/buildubimicro.sh
+++ b/buildubimicro.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright © 2023 Dell Inc. or its subsidiaries. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#      http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+# overrides file
+# this file, included from the Makefile, will overlay default values with environment variables
+#
+
+microcontainer=$(buildah from $1)
+micromount=$(buildah mount $microcontainer)
+dnf install --installroot $micromount --releasever=8 --nodocs --setopt install_weak_deps=false --setopt=reposdir=/etc/yum.repos.d/ libaio libuuid numactl xfsprogs e4fsprogs nfs-utils -y
+dnf clean all --installroot $micromount
+buildah umount $microcontainer
+buildah commit $microcontainer csipowerscale-ubimicro

--- a/docker.mk
+++ b/docker.mk
@@ -10,6 +10,9 @@ docker-build-image-push:
 
 podman-build:
 	@echo "Base Image is set to: $(BASEIMAGE)"
+	@echo "Adding Driver dependencies to $(BASEIMAGE)"
+	bash ./buildubimicro.sh $(BASEIMAGE)
+	@echo "Base image build: SUCCESS" $(eval BASEIMAGE=localhost/csipowerscale-ubimicro:latest)
 	@echo "Building: $(REGISTRY)/$(IMAGENAME):$(IMAGETAG)"
 	$(BUILDER) build -t "$(REGISTRY)/$(IMAGENAME):$(IMAGETAG)" -f Dockerfile.podman --target $(BUILDSTAGE) --build-arg GOPROXY=$(GOPROXY) --build-arg BASEIMAGE=$(BASEIMAGE) --build-arg GOVERSION=$(GOVERSION) .
 

--- a/helm/csi-isilon/templates/_helpers.tpl
+++ b/helm/csi-isilon/templates/_helpers.tpl
@@ -4,7 +4,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-isilon.attacherImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "registry.k8s.io/sig-storage/csi-attacher:v4.2.0" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-attacher:v4.3.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -12,7 +12,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-isilon.provisionerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "registry.k8s.io/sig-storage/csi-provisioner:v3.4.0" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-provisioner:v3.5.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -20,7 +20,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-isilon.snapshotterImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "registry.k8s.io/sig-storage/csi-snapshotter:v6.2.1" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -28,7 +28,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-isilon.resizerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "registry.k8s.io/sig-storage/csi-resizer:v1.7.0" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-resizer:v1.8.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -36,7 +36,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-isilon.registrarImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.3" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -44,7 +44,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-isilon.healthmonitorImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.8.0" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.9.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/overrides.mk
+++ b/overrides.mk
@@ -1,4 +1,4 @@
-# Copyright © 2020-2022 Dell Inc. or its subsidiaries. All Rights Reserved.
+# Copyright © 2020-2023 Dell Inc. or its subsidiaries. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,8 +15,8 @@
 #
 
 # DEFAULT values
-# ubi8/ubi-minimal:8.7-1085
-DEFAULT_BASEIMAGE="registry.access.redhat.com/ubi8/ubi-minimal@sha256:ab03679e683010d485ef0399e056b09a38d7843ba4a36ee7dec337dd0037f7a7"
+# ubi8/ubi-micro:8.8-1
+DEFAULT_BASEIMAGE="registry.access.redhat.com/ubi8/ubi-micro:8.8-1"
 DEFAULT_GOVERSION="1.20"
 DEFAULT_REGISTRY=""
 DEFAULT_IMAGENAME="isilon"


### PR DESCRIPTION
# Description

- ubi image updated to micro
- sidecar update to latest available

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/743|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Build image using ubi-micro as baseimage
```
--> db11f5287cb
[2/3] STEP 1/3: FROM localhost/csipowerscale-ubimicro:latest AS driver
[2/3] STEP 2/3: COPY --from=builder /go/src/csi-isilon /
--> 64decfb80bf
[2/3] STEP 3/3: ENTRYPOINT ["/csi-isilon"]
--> 32698269154
[3/3] STEP 1/3: FROM 32698269154aa38560f84f63931e77a99e125257d97fd604399552693adfdfd3 AS final
[3/3] STEP 2/3: LABEL vendor="Dell Inc."       name="csi-isilon"       summary="CSI Driver for Dell EMC PowerScale"       description="CSI Driver for provisioning persistent storage from Dell EMC PowerScale"       version="2.7.0"       license="Apache-2.0"
--> 4ce32bb5222
[3/3] STEP 3/3: COPY ./licenses /licenses
[3/3] COMMIT amaas-eos-mw1.cec.lab.emc.com:5028/csi-isilon/isilon:20230601083637
--> f209bd4f610
Successfully tagged xxxxxxxxx/csi-isilon/isilon:20230601083637
f209bd4f61014bd17d8389f734aaa35b3e4dfd9e4a8aea8d436ffb6b1cfdb16d
```

- [ ] Tested Driver installation along with pvc, pod creation
```
# kubectl get po -n isilon
NAME                                 READY   STATUS    RESTARTS   AGE
isilon-controller-7ffbd66795-p5prr   6/6     Running   0          2m47s
isilon-node-84s7d                    2/2     Running   0          2m47s
# kubectl get pvc,po
NAME                             STATUS   VOLUME           CAPACITY   ACCESS MODES   STORAGECLASS   AGE
persistentvolumeclaim/test-pvc   Bound    k8s-aafb17e602   5Gi        RWO            isilon         115s

NAME               READY   STATUS    RESTARTS   AGE
pod/ngnix-pv-pod   1/1     Running   0          87s
```

