### PR TITLE
Support nodes that are multi-homed and have two or more interfaces configured for the same network, with the custom topology

### DIFF
--- a/common/constants/envvars.go
+++ b/common/constants/envvars.go
@@ -105,4 +105,7 @@ const (
 
 	// EnvMetadataRetrieverEndpoint specifies the endpoint address for csi-metadata-retriever sidecar
 	EnvMetadataRetrieverEndpoint = "CSI_RETRIEVER_ENDPOINT"
+
+	// EnvConnectivityTestTimeout specifies the timeout value for connectivity test against the clusters
+	EnvConnectivityTestTimeout = "X_CSI_CONNECTIVITY_TEST_TIMEOUT"
 )

--- a/common/utils/utils.go
+++ b/common/utils/utils.go
@@ -26,6 +26,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Showmax/go-fqdn"
 	"github.com/container-storage-interface/spec/lib/go/csi"
@@ -89,6 +90,18 @@ func ParseInt64FromContext(ctx context.Context, key string) (int64, error) {
 			return 0, fmt.Errorf("invalid int64 value '%v' specified for '%s'", val, key)
 		}
 		return i, nil
+	}
+	return 0, nil
+}
+
+// ParseDurationFromContext parses an environment variable into an time.Duration value.
+func ParseDurationFromContext(ctx context.Context, key string) (time.Duration, error) {
+	if val, ok := csictx.LookupEnv(ctx, key); ok {
+		d, err := time.ParseDuration(val)
+		if err != nil {
+			return 0, fmt.Errorf("invalid duration value '%v' specified for '%s'", val, key)
+		}
+		return d, nil
 	}
 	return 0, nil
 }

--- a/service/mount.go
+++ b/service/mount.go
@@ -35,6 +35,7 @@ func publishVolume(
 	ctx context.Context,
 	req *csi.NodePublishVolumeRequest,
 	nfsExportURL string,
+	clientIP string,
 ) error {
 	// Fetch log handler
 	ctx, log := GetLogger(ctx)
@@ -77,6 +78,8 @@ func publishVolume(
 	}
 
 	mntOptions = append(mntOptions, rwOption)
+
+	mntOptions = append(mntOptions, fmt.Sprintf("clientaddr=%s", clientIP))
 
 	f := logrus.Fields{
 		"ID":         req.VolumeId,


### PR DESCRIPTION
# Description

This patch implements support for the scenario with multi-homed nodes that have two or more interfaces configured for the same network, with the custom topology.

# GitHub Issues

None

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

1. Build a new image from the modified code and push it to a private container registry.
2. Create a kubernetes cluster with nodes that have multiple network interfaces configured.
3. Install the CSI operator.
4. Install the modified CSI driver with the operator.
5. Create a rwx PVC manifest and launch pods that mount the PVC as a demonset.
6. Check if the NFS export is configured with the expected node addresses. 
7. Check if the pods become running and have mounts.

