### PR TITLE
fix: parse normalized snapshotID

### DIFF
--- a/common/utils/utils.go
+++ b/common/utils/utils.go
@@ -379,15 +379,18 @@ func GetNormalizedSnapshotID(ctx context.Context, snapshotID, clusterName, acces
 func ParseNormalizedSnapshotID(ctx context.Context, snapID string) (string, string, string, error) {
 	log := GetRunIDLogger(ctx)
 	tokens := strings.Split(snapID, SnapshotIDSeparator)
-	if len(tokens) < 1 {
+	if len(tokens) < 1 || snapID == "" {
 		return "", "", "", fmt.Errorf("snapshot ID '%s' cannot be split into tokens", snapID)
 	}
 
 	snapshotID := tokens[0]
 	var clusterName, accessZone string
-	if len(tokens) > 1 {
+	if len(tokens) > 2 {
 		clusterName = tokens[1]
 		accessZone = tokens[2]
+	} else if len(tokens) > 1 {
+		clusterName = tokens[1]
+		accessZone = ""
 	}
 
 	log.Debugf("normalized snapshot ID '%s' parsed into snapshot ID '%s' and cluster name '%s'",

--- a/common/utils/utils.go
+++ b/common/utils/utils.go
@@ -380,7 +380,7 @@ func ParseNormalizedSnapshotID(ctx context.Context, snapID string) (string, stri
 	log := GetRunIDLogger(ctx)
 	tokens := strings.Split(snapID, SnapshotIDSeparator)
 	if len(tokens) < 1 || snapID == "" {
-		return "", "", "", fmt.Errorf("snapshot ID '%s' cannot be split into tokens", snapID)
+		return "", "", "", fmt.Errorf("snapshot ID cannot be split into tokens")
 	}
 
 	snapshotID := tokens[0]

--- a/common/utils/utils.go
+++ b/common/utils/utils.go
@@ -393,8 +393,8 @@ func ParseNormalizedSnapshotID(ctx context.Context, snapID string) (string, stri
 		accessZone = ""
 	}
 
-	log.Debugf("normalized snapshot ID '%s' parsed into snapshot ID '%s' and cluster name '%s'",
-		snapID, snapshotID, clusterName)
+	log.Debugf("normalized snapshot ID '%s' parsed into snapshot ID '%s', cluster name '%s' and access zone '%s'",
+		snapID, snapshotID, clusterName, accessZone)
 
 	return snapshotID, clusterName, accessZone, nil
 }

--- a/common/utils/utils_test.go
+++ b/common/utils/utils_test.go
@@ -81,6 +81,45 @@ func TestParseNormalizedVolumeID(t *testing.T) {
 	assert.NotNil(t, err)
 }
 
+func TestParseNormalizedSnapshotID(t *testing.T) {
+	ctx := context.Background()
+
+	// snapID with id only
+	snapID, clusterName, accessZone, err := ParseNormalizedSnapshotID(ctx, "12345")
+	assert.Equal(t, "12345", snapID)
+	assert.Equal(t, "", clusterName)
+	assert.Equal(t, "", accessZone)
+	assert.Nil(t, err)
+
+	// snapID with id and cluster
+	snapID, clusterName, accessZone, err = ParseNormalizedSnapshotID(ctx, "12345=_=_=cluster1")
+	assert.Equal(t, "12345", snapID)
+	assert.Equal(t, "cluster1", clusterName)
+	assert.Equal(t, "", accessZone)
+	assert.Nil(t, err)
+
+	// snapID with id, cluster and zone
+	snapID, clusterName, accessZone, err = ParseNormalizedSnapshotID(ctx, "12345=_=_=cluster1=_=_=zone1")
+	assert.Equal(t, "12345", snapID)
+	assert.Equal(t, "cluster1", clusterName)
+	assert.Equal(t, "zone1", accessZone)
+	assert.Nil(t, err)
+
+	// snapID with id, cluster, zone and additional suffix
+	snapID, clusterName, accessZone, err = ParseNormalizedSnapshotID(ctx, "12345=_=_=cluster1=_=_=zone1=_=_=suffix")
+	assert.Equal(t, "12345", snapID)
+	assert.Equal(t, "cluster1", clusterName)
+	assert.Equal(t, "zone1", accessZone)
+	assert.Nil(t, err)
+
+	// empty snapID
+	snapID, clusterName, accessZone, err = ParseNormalizedSnapshotID(ctx, "")
+	assert.Equal(t, "", snapID)
+	assert.Equal(t, "", clusterName)
+	assert.Equal(t, "", accessZone)
+	assert.NotNil(t, err)
+}
+
 func TestGetPathForVolume(t *testing.T) {
 	isiPath := "/ifs/data"
 	volName := "k8s-123456"


### PR DESCRIPTION
# Description
- bug fixing connected with parsing normalized snapshotID
- writing additional unit tests

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1104 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests
```
1) Package csi-powerscale/service
363 scenarios (363 passed)
1915 steps (1915 passed)
1m40.302991248s
godog finished
=== RUN   TestMkdirCreateDir
time="2024-02-14T05:21:45-05:00" level=debug   msg="created directory" file="/home/gosia/repos/csi-powerscale/service/mount.go:201"
--- PASS: TestMkdirCreateDir (0.00s)
=== RUN   TestMkdirExistingDir
--- PASS: TestMkdirExistingDir (0.00s)
=== RUN   TestMkdirExistingFile
--- PASS: TestMkdirExistingFile (0.00s)
PASS
coverage: 79.2% of statements
status 0
ok      github.com/dell/csi-isilon/v2/service   100.421s

2) Package csi-powerscale/common/utils
PASS
coverage: 45.9% of statements
ok      github.com/dell/csi-isilon/v2/common/utils      0.609s

