### PR TITLE
Remove mutex locks from interceptors on method calls

### DIFF
--- a/provider/provider.go
+++ b/provider/provider.go
@@ -40,7 +40,6 @@ func New() gocsi.StoragePluginProvider {
 	maxStreams := grpc.MaxConcurrentStreams(8)
 	serverOptions := make([]grpc.ServerOption, 1)
 	serverOptions[0] = maxStreams
-	log.Info("Chiman: created new storage plugin provider")
 	svc := service.New()
 
 	interList := []grpc.UnaryServerInterceptor{

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -40,7 +40,7 @@ func New() gocsi.StoragePluginProvider {
 	maxStreams := grpc.MaxConcurrentStreams(8)
 	serverOptions := make([]grpc.ServerOption, 1)
 	serverOptions[0] = maxStreams
-
+	log.Info("created new storage plugin provider")
 	svc := service.New()
 
 	interList := []grpc.UnaryServerInterceptor{

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -40,7 +40,7 @@ func New() gocsi.StoragePluginProvider {
 	maxStreams := grpc.MaxConcurrentStreams(8)
 	serverOptions := make([]grpc.ServerOption, 1)
 	serverOptions[0] = maxStreams
-	log.Info("created new storage plugin provider")
+	log.Info("Chiman: created new storage plugin provider")
 	svc := service.New()
 
 	interList := []grpc.UnaryServerInterceptor{

--- a/service/controller.go
+++ b/service/controller.go
@@ -1103,6 +1103,7 @@ func (s *service) ControllerPublishVolume(
 			utils.GetMessageWithRunID(runID, "volume ID is required"))
 	}
 
+	log.Info("got volume ID:", volID)
 	volName, exportID, accessZone, clusterName, err := utils.ParseNormalizedVolumeID(ctx, volID)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, utils.GetMessageWithRunID(runID, "failed to parse volume ID '%s', error : '%v'", volID, err))

--- a/service/controller.go
+++ b/service/controller.go
@@ -1103,7 +1103,6 @@ func (s *service) ControllerPublishVolume(
 			utils.GetMessageWithRunID(runID, "volume ID is required"))
 	}
 
-	log.Info("Chiman: got volume ID:", volID)
 	volName, exportID, accessZone, clusterName, err := utils.ParseNormalizedVolumeID(ctx, volID)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, utils.GetMessageWithRunID(runID, "failed to parse volume ID '%s', error : '%v'", volID, err))

--- a/service/controller.go
+++ b/service/controller.go
@@ -1103,7 +1103,7 @@ func (s *service) ControllerPublishVolume(
 			utils.GetMessageWithRunID(runID, "volume ID is required"))
 	}
 
-	log.Info("got volume ID:", volID)
+	log.Info("Chiman: got volume ID:", volID)
 	volName, exportID, accessZone, clusterName, err := utils.ParseNormalizedVolumeID(ctx, volID)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, utils.GetMessageWithRunID(runID, "failed to parse volume ID '%s', error : '%v'", volID, err))

--- a/service/interceptor/interceptor.go
+++ b/service/interceptor/interceptor.go
@@ -122,6 +122,12 @@ func NewCustomSerialLock() grpc.UnaryServerInterceptor {
 			return i.nodeStageVolume(ctx, t, info, handler)
 		case *csi.NodeUnstageVolumeRequest:
 			return i.nodeUnstageVolume(ctx, t, info, handler)
+		case *csi.DeleteVolumeRequest:
+			return i.deleteVolume(ctx, t, info, handler)
+		case *csi.NodePublishVolumeRequest:
+			return i.nodePublishVolume(ctx, t, info, handler)
+		case *csi.NodeUnpublishVolumeRequest:
+			return i.nodeUnpublishVolume(ctx, t, info, handler)
 		default:
 			return gocsiSerializer(ctx, req, info, handler)
 		}
@@ -213,6 +219,24 @@ func (i *interceptor) nodeStageVolume(ctx context.Context, req *csi.NodeStageVol
 }
 
 func (i *interceptor) nodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest,
+	_ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
+) (res interface{}, resErr error) {
+	return handler(ctx, req)
+}
+
+func (i *interceptor) deleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest,
+	_ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
+) (res interface{}, resErr error) {
+	return handler(ctx, req)
+}
+
+func (i *interceptor) nodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest,
+	_ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
+) (res interface{}, resErr error) {
+	return handler(ctx, req)
+}
+
+func (i *interceptor) nodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest,
 	_ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
 ) (res interface{}, resErr error) {
 	return handler(ctx, req)

--- a/service/interceptor/interceptor.go
+++ b/service/interceptor/interceptor.go
@@ -48,6 +48,7 @@ func (r *rewriteRequestIDInterceptor) handleServer(ctx context.Context, req inte
 
 // NewRewriteRequestIDInterceptor creates new unary interceptor that rewrites request IDs
 func NewRewriteRequestIDInterceptor() grpc.UnaryServerInterceptor {
+	log.Info("calling NewRewriteRequestIDInterceptor")
 	interceptor := &rewriteRequestIDInterceptor{}
 	return interceptor.handleServer
 }
@@ -61,6 +62,8 @@ type lockProvider struct {
 
 func (i *lockProvider) GetLockWithID(_ context.Context, id string) (gosync.TryLocker, error) {
 	i.volIDLocksL.Lock()
+	log.Info("calling GetLockWithID")
+	defer log.Info("calling end GetLockWithID")
 	defer i.volIDLocksL.Unlock()
 
 	lock := i.volIDLocks[id]
@@ -74,6 +77,8 @@ func (i *lockProvider) GetLockWithID(_ context.Context, id string) (gosync.TryLo
 
 func (i *lockProvider) GetLockWithName(_ context.Context, name string) (gosync.TryLocker, error) {
 	i.volNameLocksL.Lock()
+	log.Info("calling GetLockWithName")
+	defer log.Info("calling end GetLockWithName")
 	defer i.volNameLocksL.Unlock()
 
 	lock := i.volNameLocks[name]

--- a/service/interceptor/interceptor.go
+++ b/service/interceptor/interceptor.go
@@ -48,7 +48,6 @@ func (r *rewriteRequestIDInterceptor) handleServer(ctx context.Context, req inte
 
 // NewRewriteRequestIDInterceptor creates new unary interceptor that rewrites request IDs
 func NewRewriteRequestIDInterceptor() grpc.UnaryServerInterceptor {
-	log.Info("Chiman: calling NewRewriteRequestIDInterceptor")
 	interceptor := &rewriteRequestIDInterceptor{}
 	return interceptor.handleServer
 }
@@ -102,7 +101,6 @@ type interceptor struct {
 
 // NewCustomSerialLock creates new unary interceptor that locks gRPC requests
 func NewCustomSerialLock() grpc.UnaryServerInterceptor {
-	log.Info("Chiman: calling NewCustomSerialLock")
 	locker := &lockProvider{
 		volIDLocks:   map[string]gosync.TryLocker{},
 		volNameLocks: map[string]gosync.TryLocker{},
@@ -117,10 +115,8 @@ func NewCustomSerialLock() grpc.UnaryServerInterceptor {
 	handle := func(ctx xctx.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		switch t := req.(type) {
 		case *csi.CreateVolumeRequest:
-			log.Info("Chiman: calling CreateVolumeRequest condition")
 			return i.createVolume(ctx, t, info, handler)
 		case *csi.NodeStageVolumeRequest:
-			log.Info("Chiman: calling NodeStageVolumeRequest condition")
 			return i.nodeStageVolume(ctx, t, info, handler)
 		case *csi.NodeUnstageVolumeRequest:
 			return i.nodeUnstageVolume(ctx, t, info, handler)

--- a/service/interceptor/interceptor.go
+++ b/service/interceptor/interceptor.go
@@ -48,7 +48,7 @@ func (r *rewriteRequestIDInterceptor) handleServer(ctx context.Context, req inte
 
 // NewRewriteRequestIDInterceptor creates new unary interceptor that rewrites request IDs
 func NewRewriteRequestIDInterceptor() grpc.UnaryServerInterceptor {
-	log.Info("calling NewRewriteRequestIDInterceptor")
+	log.Info("Chiman: calling NewRewriteRequestIDInterceptor")
 	interceptor := &rewriteRequestIDInterceptor{}
 	return interceptor.handleServer
 }
@@ -62,8 +62,8 @@ type lockProvider struct {
 
 func (i *lockProvider) GetLockWithID(_ context.Context, id string) (gosync.TryLocker, error) {
 	i.volIDLocksL.Lock()
-	log.Info("calling GetLockWithID")
-	defer log.Info("calling end GetLockWithID")
+	log.Info("Chiman: calling GetLockWithID")
+	defer log.Info("Chiman: calling end GetLockWithID")
 	defer i.volIDLocksL.Unlock()
 
 	lock := i.volIDLocks[id]
@@ -77,8 +77,8 @@ func (i *lockProvider) GetLockWithID(_ context.Context, id string) (gosync.TryLo
 
 func (i *lockProvider) GetLockWithName(_ context.Context, name string) (gosync.TryLocker, error) {
 	i.volNameLocksL.Lock()
-	log.Info("calling GetLockWithName")
-	defer log.Info("calling end GetLockWithName")
+	log.Info("Chiman: calling GetLockWithName")
+	defer log.Info("Chiman: calling end GetLockWithName")
 	defer i.volNameLocksL.Unlock()
 
 	lock := i.volNameLocks[name]
@@ -102,7 +102,7 @@ type interceptor struct {
 
 // NewCustomSerialLock creates new unary interceptor that locks gRPC requests
 func NewCustomSerialLock() grpc.UnaryServerInterceptor {
-	log.Info("calling NewCustomSerialLock")
+	log.Info("Chiman: calling NewCustomSerialLock")
 	locker := &lockProvider{
 		volIDLocks:   map[string]gosync.TryLocker{},
 		volNameLocks: map[string]gosync.TryLocker{},
@@ -117,15 +117,15 @@ func NewCustomSerialLock() grpc.UnaryServerInterceptor {
 	handle := func(ctx xctx.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		switch t := req.(type) {
 		case *csi.CreateVolumeRequest:
-			log.Info("calling CreateVolumeRequest condition")
+			log.Info("Chiman: calling CreateVolumeRequest condition")
 			return i.createVolume(ctx, t, info, handler)
 		case *csi.NodeStageVolumeRequest:
-			log.Info("calling NodeStageVolumeRequest condition")
+			log.Info("Chiman: calling NodeStageVolumeRequest condition")
 			return i.nodeStageVolume(ctx, t, info, handler)
 		case *csi.NodeUnstageVolumeRequest:
 			return i.nodeUnstageVolume(ctx, t, info, handler)
 		default:
-			log.Info("calling default condition")
+			log.Info("Chiman: request type", t, "calling default condition")
 			return gocsiSerializer(ctx, req, info, handler)
 		}
 	}

--- a/service/interceptor/interceptor.go
+++ b/service/interceptor/interceptor.go
@@ -97,6 +97,7 @@ type interceptor struct {
 
 // NewCustomSerialLock creates new unary interceptor that locks gRPC requests
 func NewCustomSerialLock() grpc.UnaryServerInterceptor {
+	log.Info("calling NewCustomSerialLock")
 	locker := &lockProvider{
 		volIDLocks:   map[string]gosync.TryLocker{},
 		volNameLocks: map[string]gosync.TryLocker{},
@@ -111,12 +112,15 @@ func NewCustomSerialLock() grpc.UnaryServerInterceptor {
 	handle := func(ctx xctx.Context, req interface{}, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
 		switch t := req.(type) {
 		case *csi.CreateVolumeRequest:
+			log.Info("calling CreateVolumeRequest condition")
 			return i.createVolume(ctx, t, info, handler)
 		case *csi.NodeStageVolumeRequest:
+			log.Info("calling NodeStageVolumeRequest condition")
 			return i.nodeStageVolume(ctx, t, info, handler)
 		case *csi.NodeUnstageVolumeRequest:
 			return i.nodeUnstageVolume(ctx, t, info, handler)
 		default:
+			log.Info("calling default condition")
 			return gocsiSerializer(ctx, req, info, handler)
 		}
 	}

--- a/service/interceptor/interceptor.go
+++ b/service/interceptor/interceptor.go
@@ -26,6 +26,8 @@ import (
 	"github.com/kubernetes-csi/csi-lib-utils/metrics"
 )
 
+const pending = "pending"
+
 type rewriteRequestIDInterceptor struct{}
 
 func (r *rewriteRequestIDInterceptor) handleServer(ctx context.Context, req interface{},
@@ -154,17 +156,17 @@ func (i *interceptor) createMetadataRetrieverClient(ctx context.Context) {
 	}
 }
 
-const pending = "pending"
-
-func (i *interceptor) nodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest,
+func (i *interceptor) controllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest,
 	_ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
 ) (res interface{}, resErr error) {
+	log.Info("Chiman: request type", req, "this method")
 	return handler(ctx, req)
 }
 
-func (i *interceptor) nodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest,
+func (i *interceptor) controllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest,
 	_ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
 ) (res interface{}, resErr error) {
+	log.Info("Chiman: request type", req, "this method")
 	return handler(ctx, req)
 }
 
@@ -211,16 +213,14 @@ func (i *interceptor) createVolume(ctx context.Context, req *csi.CreateVolumeReq
 	return handler(ctx, req)
 }
 
-func (i *interceptor) controllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest,
+func (i *interceptor) nodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest,
 	_ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
 ) (res interface{}, resErr error) {
-	log.Info("Chiman: request type", req, "this method")
 	return handler(ctx, req)
 }
 
-func (i *interceptor) controllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest,
+func (i *interceptor) nodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest,
 	_ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
 ) (res interface{}, resErr error) {
-	log.Info("Chiman: request type", req, "this method")
 	return handler(ctx, req)
 }

--- a/service/interceptor/interceptor.go
+++ b/service/interceptor/interceptor.go
@@ -157,18 +157,24 @@ func (i *interceptor) createMetadataRetrieverClient(ctx context.Context) {
 	}
 }
 
+// controllerPublishVolume returns a new server-side, gRPC interceptor
+// that provides serial access to volume resources for the ControllerPublishVolume RPC
 func (i *interceptor) controllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest,
 	_ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
 ) (res interface{}, resErr error) {
 	return handler(ctx, req)
 }
 
+// controllerUnpublishVolume returns a new server-side, gRPC interceptor
+// that provides serial access to volume resources for the ControllerUnpublishVolume RPC
 func (i *interceptor) controllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest,
 	_ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
 ) (res interface{}, resErr error) {
 	return handler(ctx, req)
 }
 
+// createVolume returns a new server-side, gRPC interceptor
+// that provides serial access to volume resources for the CreateVolume RPC
 func (i *interceptor) createVolume(ctx context.Context, req *csi.CreateVolumeRequest,
 	_ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
 ) (res interface{}, resErr error) {
@@ -212,30 +218,40 @@ func (i *interceptor) createVolume(ctx context.Context, req *csi.CreateVolumeReq
 	return handler(ctx, req)
 }
 
+// nodeStageVolume returns a new server-side, gRPC interceptor
+// that provides serial access to volume resources for the NodeStageVolume RPC
 func (i *interceptor) nodeStageVolume(ctx context.Context, req *csi.NodeStageVolumeRequest,
 	_ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
 ) (res interface{}, resErr error) {
 	return handler(ctx, req)
 }
 
+// nodeUnstageVolume returns a new server-side, gRPC interceptor
+// that provides serial access to volume resources for the NodeUnstageVolume RPC
 func (i *interceptor) nodeUnstageVolume(ctx context.Context, req *csi.NodeUnstageVolumeRequest,
 	_ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
 ) (res interface{}, resErr error) {
 	return handler(ctx, req)
 }
 
+// deleteVolume returns a new server-side, gRPC interceptor
+// that provides serial access to volume resources for the DeleteVolume RPC
 func (i *interceptor) deleteVolume(ctx context.Context, req *csi.DeleteVolumeRequest,
 	_ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
 ) (res interface{}, resErr error) {
 	return handler(ctx, req)
 }
 
+// nodePublishVolume returns a new server-side, gRPC interceptor
+// that provides serial access to volume resources for the NodePublishVolume RPC
 func (i *interceptor) nodePublishVolume(ctx context.Context, req *csi.NodePublishVolumeRequest,
 	_ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
 ) (res interface{}, resErr error) {
 	return handler(ctx, req)
 }
 
+// nodeUnpublishVolume returns a new server-side, gRPC interceptor
+// that provides serial access to volume resources for the NodeUnpublishVolume RPC
 func (i *interceptor) nodeUnpublishVolume(ctx context.Context, req *csi.NodeUnpublishVolumeRequest,
 	_ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
 ) (res interface{}, resErr error) {

--- a/service/interceptor/interceptor.go
+++ b/service/interceptor/interceptor.go
@@ -118,12 +118,12 @@ func NewCustomSerialLock() grpc.UnaryServerInterceptor {
 			return i.controllerUnpublishVolume(ctx, t, info, handler)
 		case *csi.CreateVolumeRequest:
 			return i.createVolume(ctx, t, info, handler)
+		case *csi.DeleteVolumeRequest:
+			return i.deleteVolume(ctx, t, info, handler)
 		case *csi.NodeStageVolumeRequest:
 			return i.nodeStageVolume(ctx, t, info, handler)
 		case *csi.NodeUnstageVolumeRequest:
 			return i.nodeUnstageVolume(ctx, t, info, handler)
-		case *csi.DeleteVolumeRequest:
-			return i.deleteVolume(ctx, t, info, handler)
 		case *csi.NodePublishVolumeRequest:
 			return i.nodePublishVolume(ctx, t, info, handler)
 		case *csi.NodeUnpublishVolumeRequest:

--- a/service/interceptor/interceptor.go
+++ b/service/interceptor/interceptor.go
@@ -63,8 +63,6 @@ type lockProvider struct {
 
 func (i *lockProvider) GetLockWithID(_ context.Context, id string) (gosync.TryLocker, error) {
 	i.volIDLocksL.Lock()
-	log.Info("Chiman: calling GetLockWithID")
-	defer log.Info("Chiman: calling end GetLockWithID")
 	defer i.volIDLocksL.Unlock()
 
 	lock := i.volIDLocks[id]
@@ -78,8 +76,6 @@ func (i *lockProvider) GetLockWithID(_ context.Context, id string) (gosync.TryLo
 
 func (i *lockProvider) GetLockWithName(_ context.Context, name string) (gosync.TryLocker, error) {
 	i.volNameLocksL.Lock()
-	log.Info("Chiman: calling GetLockWithName")
-	defer log.Info("Chiman: calling end GetLockWithName")
 	defer i.volNameLocksL.Unlock()
 
 	lock := i.volNameLocks[name]
@@ -127,7 +123,6 @@ func NewCustomSerialLock() grpc.UnaryServerInterceptor {
 		case *csi.NodeUnstageVolumeRequest:
 			return i.nodeUnstageVolume(ctx, t, info, handler)
 		default:
-			log.Info("Chiman: request type", t, "calling default condition")
 			return gocsiSerializer(ctx, req, info, handler)
 		}
 	}
@@ -159,14 +154,12 @@ func (i *interceptor) createMetadataRetrieverClient(ctx context.Context) {
 func (i *interceptor) controllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest,
 	_ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
 ) (res interface{}, resErr error) {
-	log.Info("Chiman: request type", req, "this method")
 	return handler(ctx, req)
 }
 
 func (i *interceptor) controllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest,
 	_ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
 ) (res interface{}, resErr error) {
-	log.Info("Chiman: request type", req, "this method")
 	return handler(ctx, req)
 }
 

--- a/service/interceptor/interceptor.go
+++ b/service/interceptor/interceptor.go
@@ -120,6 +120,9 @@ func NewCustomSerialLock() grpc.UnaryServerInterceptor {
 			return i.nodeStageVolume(ctx, t, info, handler)
 		case *csi.NodeUnstageVolumeRequest:
 			return i.nodeUnstageVolume(ctx, t, info, handler)
+		case *csi.ControllerPublishVolumeRequest:
+			log.Info("Chiman: request type", t, "calling ControllerPublishVolumeRequest condition")
+			return i.controllerPublishVolume(ctx, t, info, handler)
 		default:
 			log.Info("Chiman: request type", t, "calling default condition")
 			return gocsiSerializer(ctx, req, info, handler)
@@ -230,5 +233,12 @@ func (i *interceptor) createVolume(ctx context.Context, req *csi.CreateVolumeReq
 		}
 	}
 
+	return handler(ctx, req)
+}
+
+func (i *interceptor) controllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest,
+	_ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
+) (res interface{}, resErr error) {
+	log.Info("Chiman: request type", req, "this method")
 	return handler(ctx, req)
 }

--- a/service/interceptor/interceptor.go
+++ b/service/interceptor/interceptor.go
@@ -121,8 +121,9 @@ func NewCustomSerialLock() grpc.UnaryServerInterceptor {
 		case *csi.NodeUnstageVolumeRequest:
 			return i.nodeUnstageVolume(ctx, t, info, handler)
 		case *csi.ControllerPublishVolumeRequest:
-			log.Info("Chiman: request type", t, "calling ControllerPublishVolumeRequest condition")
 			return i.controllerPublishVolume(ctx, t, info, handler)
+		case *csi.ControllerUnpublishVolumeRequest:
+			return i.controllerUnpublishVolume(ctx, t, info, handler)
 		default:
 			log.Info("Chiman: request type", t, "calling default condition")
 			return gocsiSerializer(ctx, req, info, handler)
@@ -237,6 +238,13 @@ func (i *interceptor) createVolume(ctx context.Context, req *csi.CreateVolumeReq
 }
 
 func (i *interceptor) controllerPublishVolume(ctx context.Context, req *csi.ControllerPublishVolumeRequest,
+	_ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
+) (res interface{}, resErr error) {
+	log.Info("Chiman: request type", req, "this method")
+	return handler(ctx, req)
+}
+
+func (i *interceptor) controllerUnpublishVolume(ctx context.Context, req *csi.ControllerUnpublishVolumeRequest,
 	_ *grpc.UnaryServerInfo, handler grpc.UnaryHandler,
 ) (res interface{}, resErr error) {
 	log.Info("Chiman: request type", req, "this method")

--- a/service/interceptor/interceptor_test.go
+++ b/service/interceptor/interceptor_test.go
@@ -87,15 +87,13 @@ func TestNewCustomSerialLock(t *testing.T) {
 	t.Run("NodeStage for same volume concurrent call", func(t *testing.T) {
 		err := runTest(&csi.NodeStageVolumeRequest{VolumeId: validBlockVolumeID},
 			&csi.NodeStageVolumeRequest{VolumeId: validBlockVolumeID})
-		assert.NotNil(t, err)
-		assert.Contains(t, err.Error(), "pending")
+		assert.Nil(t, err)
 	})
 
 	t.Run("NodeUnstage for same volume concurrent call", func(t *testing.T) {
 		err := runTest(&csi.NodeUnstageVolumeRequest{VolumeId: validBlockVolumeID},
 			&csi.NodeUnstageVolumeRequest{VolumeId: validBlockVolumeID})
-		assert.NotNil(t, err)
-		assert.Contains(t, err.Error(), "pending")
+		assert.Nil(t, err)
 	})
 
 	t.Run("NodeUnstage for different volumes", func(t *testing.T) {
@@ -113,15 +111,13 @@ func TestNewCustomSerialLock(t *testing.T) {
 	t.Run("NodePublish for same volume concurrent call", func(t *testing.T) {
 		err := runTest(&csi.NodePublishVolumeRequest{VolumeId: validBlockVolumeID},
 			&csi.NodePublishVolumeRequest{VolumeId: validBlockVolumeID})
-		assert.NotNil(t, err)
-		assert.Contains(t, err.Error(), "pending")
+		assert.Nil(t, err)
 	})
 
 	t.Run("NodePublish and NodeStage for same volume concurrent call", func(t *testing.T) {
 		err := runTest(&csi.NodeStageVolumeRequest{VolumeId: validBlockVolumeID},
 			&csi.NodePublishVolumeRequest{VolumeId: validBlockVolumeID})
-		assert.NotNil(t, err)
-		assert.Contains(t, err.Error(), "pending")
+		assert.Nil(t, err)
 	})
 
 	t.Run("CreateVolume for same volume concurrent call", func(t *testing.T) {

--- a/service/interceptor/interceptor_test.go
+++ b/service/interceptor/interceptor_test.go
@@ -84,9 +84,65 @@ func TestNewCustomSerialLock(t *testing.T) {
 		wg.Wait()
 		return err
 	}
+
+	t.Run("ControllerPublishVolume for same volume concurrent call", func(t *testing.T) {
+		err := runTest(&csi.ControllerPublishVolumeRequest{VolumeId: validBlockVolumeID},
+			&csi.ControllerPublishVolumeRequest{VolumeId: validBlockVolumeID})
+		assert.Nil(t, err)
+	})
+
+	t.Run("ControllerPublishVolume for different volumes", func(t *testing.T) {
+		err := runTest(&csi.ControllerPublishVolumeRequest{VolumeId: validBlockVolumeID},
+			&csi.ControllerPublishVolumeRequest{VolumeId: validNfsVolumeID})
+		assert.Nil(t, err)
+	})
+
+	t.Run("ControllerUnpublishVolume for same volume concurrent call", func(t *testing.T) {
+		err := runTest(&csi.ControllerUnpublishVolumeRequest{VolumeId: validBlockVolumeID},
+			&csi.ControllerUnpublishVolumeRequest{VolumeId: validBlockVolumeID})
+		assert.Nil(t, err)
+	})
+
+	t.Run("ControllerUnpublishVolume for different volumes", func(t *testing.T) {
+		err := runTest(&csi.ControllerUnpublishVolumeRequest{VolumeId: validBlockVolumeID},
+			&csi.ControllerUnpublishVolumeRequest{VolumeId: validNfsVolumeID})
+		assert.Nil(t, err)
+	})
+
+	t.Run("CreateVolume for same volume concurrent call", func(t *testing.T) {
+		err := runTest(&csi.CreateVolumeRequest{Name: validBlockVolumeID},
+			&csi.CreateVolumeRequest{Name: validBlockVolumeID})
+		assert.NotNil(t, err)
+		assert.Contains(t, err.Error(), "pending")
+	})
+
+	t.Run("CreateVolume for different volumes", func(t *testing.T) {
+		err := runTest(&csi.CreateVolumeRequest{Name: validBlockVolumeID},
+			&csi.CreateVolumeRequest{Name: validNfsVolumeID})
+		assert.Nil(t, err)
+	})
+
+	t.Run("DeleteVolume for same volume concurrent call", func(t *testing.T) {
+		err := runTest(&csi.DeleteVolumeRequest{VolumeId: validBlockVolumeID},
+			&csi.DeleteVolumeRequest{VolumeId: validBlockVolumeID})
+		assert.Nil(t, err)
+	})
+
+	t.Run("DeleteVolume for different volumes", func(t *testing.T) {
+		err := runTest(&csi.DeleteVolumeRequest{VolumeId: validBlockVolumeID},
+			&csi.DeleteVolumeRequest{VolumeId: validNfsVolumeID})
+		assert.Nil(t, err)
+	})
+
 	t.Run("NodeStage for same volume concurrent call", func(t *testing.T) {
 		err := runTest(&csi.NodeStageVolumeRequest{VolumeId: validBlockVolumeID},
 			&csi.NodeStageVolumeRequest{VolumeId: validBlockVolumeID})
+		assert.Nil(t, err)
+	})
+
+	t.Run("NodeStage for different volumes", func(t *testing.T) {
+		err := runTest(&csi.NodeStageVolumeRequest{VolumeId: validBlockVolumeID},
+			&csi.NodeStageVolumeRequest{VolumeId: validNfsVolumeID})
 		assert.Nil(t, err)
 	})
 
@@ -102,12 +158,6 @@ func TestNewCustomSerialLock(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
-	t.Run("NodeStage for different volumes", func(t *testing.T) {
-		err := runTest(&csi.NodeStageVolumeRequest{VolumeId: validBlockVolumeID},
-			&csi.NodeStageVolumeRequest{VolumeId: validNfsVolumeID})
-		assert.Nil(t, err)
-	})
-
 	t.Run("NodePublish for same volume concurrent call", func(t *testing.T) {
 		err := runTest(&csi.NodePublishVolumeRequest{VolumeId: validBlockVolumeID},
 			&csi.NodePublishVolumeRequest{VolumeId: validBlockVolumeID})
@@ -120,15 +170,16 @@ func TestNewCustomSerialLock(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
-	t.Run("CreateVolume for same volume concurrent call", func(t *testing.T) {
-		err := runTest(&csi.CreateVolumeRequest{Name: validBlockVolumeID},
-			&csi.CreateVolumeRequest{Name: validBlockVolumeID})
-		assert.NotNil(t, err)
-		assert.Contains(t, err.Error(), "pending")
-	})
-	t.Run("CreateVolume for different volumes", func(t *testing.T) {
-		err := runTest(&csi.CreateVolumeRequest{Name: validBlockVolumeID},
-			&csi.CreateVolumeRequest{Name: validNfsVolumeID})
+	t.Run("NodeUnpublishVolume for same volume concurrent call", func(t *testing.T) {
+		err := runTest(&csi.NodeUnpublishVolumeRequest{VolumeId: validBlockVolumeID},
+			&csi.NodeUnpublishVolumeRequest{VolumeId: validBlockVolumeID})
 		assert.Nil(t, err)
 	})
+
+	t.Run("NodeUnpublishVolume for different volumes", func(t *testing.T) {
+		err := runTest(&csi.NodeUnpublishVolumeRequest{VolumeId: validBlockVolumeID},
+			&csi.NodeUnpublishVolumeRequest{VolumeId: validNfsVolumeID})
+		assert.Nil(t, err)
+	})
+
 }

--- a/service/interceptor/interceptor_test.go
+++ b/service/interceptor/interceptor_test.go
@@ -181,5 +181,4 @@ func TestNewCustomSerialLock(t *testing.T) {
 			&csi.NodeUnpublishVolumeRequest{VolumeId: validNfsVolumeID})
 		assert.Nil(t, err)
 	})
-
 }

--- a/service/mock/k8s/fakeNodeCreator.go
+++ b/service/mock/k8s/fakeNodeCreator.go
@@ -24,7 +24,7 @@ const K8sLabel = "label"
 func WriteK8sValueToFile(inputType, value string) {
 	DeleteK8sValuesFile()
 	log.Printf("writing k8s values input=%s, value=%s", inputType, value)
-	pwd, err := os.Getwd()
+	pwd, _ := os.Getwd()
 	log.Printf("cwd is path is %s", pwd)
 	file, err := os.Create(K8sValueFile)
 	if err != nil {
@@ -55,7 +55,7 @@ func DeleteK8sValuesFile() bool {
 		log.Errorf("unable get abs path of file for deletion - %s", err)
 	}
 	log.Infof("abs path for deletion is %s", abspath)
-	pwd, err := os.Getwd()
+	pwd, _ := os.Getwd()
 	log.Infof("cwd for deletion is %s", pwd)
 	err = os.Remove(K8sValueFile)
 	if err != nil {
@@ -74,7 +74,7 @@ func readAppliedLabels() (string, string) {
 		log.Errorf("unable to get abs path of filei to read due to - %s", err)
 	}
 	log.Infof("abs path to read is is %s", abspath)
-	pwd, err := os.Getwd()
+	pwd, _ := os.Getwd()
 	log.Infof("cwd while reading is path is %s", pwd)
 	content, err := os.ReadFile(K8sValueFile)
 	if err != nil {
@@ -113,7 +113,7 @@ func GetFakeNode() *v1.Node {
 	label, value := readAppliedLabels()
 	if label != "" {
 		fmt.Printf("wrote %s=%s\n", label, value)
-		labelStr := fmt.Sprintf("%s", label)
+		labelStr := label
 		val := "" + value + ""
 		labelMap[labelStr] = val
 	}


### PR DESCRIPTION
# Description
Improve performance by removing mutex calls from interceptors on method calls. Reducing unnecessary synchronization can decrease overhead and enhance system efficiency.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1438 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Run unit test
- [x] Sanity Testing
- [x] Successful image build
- [x] Successful testing of **RWX, RWO, ROX** Access modes on **3 node cluster** and **11 node cluster**.
  - I have done PV creation, pod mounting and pod deletion and PV deletion consecutively for the above configurations.
- [x] Successful installation via csm-operator and helm charts.
- [x] Tested quota feature
 
![Screenshot 2024-08-23 171608](https://github.com/user-attachments/assets/966eb49c-8ce4-42dd-bead-10a0c746ef51)
![Screenshot 2024-08-23 170352](https://github.com/user-attachments/assets/31ed1701-816b-4b7d-b94a-6840f4ddd96b)

