### PR TITLE
Update offline installer to ignore comments in the manifests.

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -25,6 +25,7 @@ jobs:
         uses: dell/common-github-actions/gosec-runner@main
         with:
           directories: "./..."
+          excludes: "G115"
   malware_security_scan:
     name: Malware Scanner
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -25,7 +25,6 @@ jobs:
         uses: dell/common-github-actions/gosec-runner@main
         with:
           directories: "./..."
-          excludes: "G115"
   malware_security_scan:
     name: Malware Scanner
     runs-on: ubuntu-latest

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -28,3 +28,4 @@ jobs:
         with:
           version: latest
           skip-cache: true
+          args: --out-format=colored-line-number

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -28,3 +28,6 @@ jobs:
         with:
           version: latest
           skip-cache: true
+        output:
+          formats:
+            - format: colored-line-number

--- a/.github/workflows/linters.yaml
+++ b/.github/workflows/linters.yaml
@@ -28,6 +28,3 @@ jobs:
         with:
           version: latest
           skip-cache: true
-        output:
-          formats:
-            - format: colored-line-number

--- a/dell-csi-helm-installer/csi-offline-bundle.sh
+++ b/dell-csi-helm-installer/csi-offline-bundle.sh
@@ -63,6 +63,7 @@ run_command() {
 # build_image_manifest
 # builds a manifest of all the images referred to by the helm chart
 build_image_manifest() {
+  local REGEX_COMMENTS="(#.*)"
   local REGEX="([-_./:A-Za-z0-9]{3,}):([-_.A-Za-z0-9]{1,})"
 
   status "Building image manifest file"
@@ -82,7 +83,7 @@ build_image_manifest() {
       # - search all files in a diectory looking for strings that make $REGEX
       # - exclude anything with double '//'' as that is a URL and not an image name
       # - make sure at least one '/' is found
-      find "${D}" -type f -exec egrep -oh "${REGEX}" {} \; | egrep -v '//' | egrep '/' >> "${IMAGEMANIFEST}.tmp"
+      find "${D}" -type f -exec egrep -v "${REGEX_COMMENTS}" {} \; | egrep -oh "${REGEX}"| egrep -v '//' | egrep '/' >> "${IMAGEMANIFEST}.tmp"
     fi
   done
 

--- a/service/service.go
+++ b/service/service.go
@@ -230,7 +230,7 @@ func (s *service) initializeServiceOpts(ctx context.Context) error {
 
 	opts.QuotaEnabled = utils.ParseBooleanFromContext(ctx, constants.EnvQuotaEnabled)
 	opts.SkipCertificateValidation = utils.ParseBooleanFromContext(ctx, constants.EnvSkipCertificateValidation)
-	opts.isiAuthType = uint8(utils.ParseUintFromContext(ctx, constants.EnvIsiAuthType))
+	opts.isiAuthType = uint8(utils.ParseUintFromContext(ctx, constants.EnvIsiAuthType)) // #nosec G115 -- This is a false positive
 	opts.AutoProbe = utils.ParseBooleanFromContext(ctx, constants.EnvAutoProbe)
 	opts.Verbose = utils.ParseUintFromContext(ctx, constants.EnvVerbose)
 	opts.CustomTopologyEnabled = utils.ParseBooleanFromContext(ctx, constants.EnvCustomTopologyEnabled)

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -1936,7 +1936,7 @@ func (f *feature) iCallListVolumesWithMaxEntriesStartingToken(arg1 int, arg2 str
 	if arg2 == "invalid" {
 		stepHandlersErrors.StartingTokenInvalidError = true
 	}
-	req.MaxEntries = int32(arg1)
+	req.MaxEntries = int32(arg1) // #nosec G115 -- This is a false positive
 	req.StartingToken = arg2
 	f.listVolumesResponse, f.err = f.service.ListVolumes(context.Background(), req)
 	if f.err != nil {

--- a/test/integration/step_defs_test.go
+++ b/test/integration/step_defs_test.go
@@ -257,7 +257,7 @@ func createIsilonClient() (*isi.Client, error) {
 		os.Getenv(constants.EnvPath),
 		os.Getenv(constants.DefaultIsiVolumePathPermissions),
 		ignoreUnresolvableHosts,
-		uint8(utils.ParseUintFromContext(ctx, constants.EnvIsiAuthType)))
+		uint8(utils.ParseUintFromContext(ctx, constants.EnvIsiAuthType))) // #nosec G115 -- This is a false positive
 	if err != nil {
 		fmt.Printf("error creating isilon client: '%s'\n", err.Error())
 	}
@@ -423,7 +423,7 @@ func (f *feature) iCallListVolumesWithMaxEntriesStartingToken(arg1 int, arg2 str
 	ctx := context.Background()
 	req := new(csi.ListVolumesRequest)
 	var resp *csi.ListVolumesResponse
-	req.MaxEntries = int32(arg1)
+	req.MaxEntries = int32(arg1) // #nosec G115 -- This is a false positive
 	req.StartingToken = arg2
 	f.listVolumesRequest = req
 	// Retry loop to deal with ISILON API being overwhelmed


### PR DESCRIPTION
# Description
Update offline installer to ignore comments in the manifests.

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

./csi-offline-bundle.sh -c

*
* Building image manifest file

   Processing files in /root/workspacecsm/csi-powerscale/helm-charts/charts/csi-isilon

*
* Pulling and saving container images

   dellemc/csi-isilon:v2.11.0
   dellemc/csi-metadata-retriever:v1.8.0
   dellemc/csm-authorization-sidecar:v1.11.0
   dellemc/csm-encryption:v0.6.0
   dellemc/dell-csi-replicator:v1.9.0
   dellemc/podmon:v1.10.0
   registry.k8s.io/sig-storage/csi-attacher:v4.6.1
   registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.12.1
   registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.10.1
   registry.k8s.io/sig-storage/csi-provisioner:v5.0.1
   registry.k8s.io/sig-storage/csi-resizer:v1.11.1
   registry.k8s.io/sig-storage/csi-snapshotter:v8.0.1


*
* Copying necessary files

 /root/workspacecsm/csi-powerscale/helm-charts/charts/csi-isilon
 /root/workspacecsm/csi-powerscale/dell-csi-helm-installer
 /root/workspacecsm/csi-powerscale/README.md
 /root/workspacecsm/csi-powerscale/LICENSE

*
* Compressing release

csi-isilon-bundle-2.11.0/
csi-isilon-bundle-2.11.0/helm-charts/
csi-isilon-bundle-2.11.0/helm-charts/charts/
csi-isilon-bundle-2.11.0/helm-charts/charts/csi-isilon/
csi-isilon-bundle-2.11.0/helm-charts/charts/csi-isilon/Chart.yaml
csi-isilon-bundle-2.11.0/helm-charts/charts/csi-isilon/values.yaml
csi-isilon-bundle-2.11.0/helm-charts/charts/csi-isilon/templates/
csi-isilon-bundle-2.11.0/helm-charts/charts/csi-isilon/templates/sec-rolebinding.yaml
csi-isilon-bundle-2.11.0/helm-charts/charts/csi-isilon/templates/node.yaml
csi-isilon-bundle-2.11.0/helm-charts/charts/csi-isilon/templates/_helpers.tpl
csi-isilon-bundle-2.11.0/helm-charts/charts/csi-isilon/templates/validation.yaml
csi-isilon-bundle-2.11.0/helm-charts/charts/csi-isilon/templates/csidriver.yaml
csi-isilon-bundle-2.11.0/helm-charts/charts/csi-isilon/templates/driver-config-params.yaml
csi-isilon-bundle-2.11.0/helm-charts/charts/csi-isilon/templates/controller.yaml
csi-isilon-bundle-2.11.0/LICENSE
csi-isilon-bundle-2.11.0/README.md
csi-isilon-bundle-2.11.0/dell-csi-helm-installer/
csi-isilon-bundle-2.11.0/dell-csi-helm-installer/common.sh
csi-isilon-bundle-2.11.0/dell-csi-helm-installer/images.tar/
csi-isilon-bundle-2.11.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-attacher-v4.6.1.tar
csi-isilon-bundle-2.11.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-resizer-v1.11.1.tar
csi-isilon-bundle-2.11.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-snapshotter-v8.0.1.tar
csi-isilon-bundle-2.11.0/dell-csi-helm-installer/images.tar/dellemc-dell-csi-replicator-v1.9.0.tar
csi-isilon-bundle-2.11.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-node-driver-registrar-v2.10.1.tar
csi-isilon-bundle-2.11.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-external-health-monitor-controller-v0.12.1.tar
csi-isilon-bundle-2.11.0/dell-csi-helm-installer/images.tar/dellemc-podmon-v1.10.0.tar
csi-isilon-bundle-2.11.0/dell-csi-helm-installer/images.tar/dellemc-csi-isilon-v2.11.0.tar
csi-isilon-bundle-2.11.0/dell-csi-helm-installer/images.tar/dellemc-csm-encryption-v0.6.0.tar
csi-isilon-bundle-2.11.0/dell-csi-helm-installer/images.tar/registry.k8s.io-sig-storage-csi-provisioner-v5.0.1.tar
csi-isilon-bundle-2.11.0/dell-csi-helm-installer/images.tar/dellemc-csm-authorization-sidecar-v1.11.0.tar
csi-isilon-bundle-2.11.0/dell-csi-helm-installer/images.tar/dellemc-csi-metadata-retriever-v1.8.0.tar
csi-isilon-bundle-2.11.0/dell-csi-helm-installer/csi-offline-bundle.md
csi-isilon-bundle-2.11.0/dell-csi-helm-installer/.gitignore
csi-isilon-bundle-2.11.0/dell-csi-helm-installer/verify-csi-isilon.sh
csi-isilon-bundle-2.11.0/dell-csi-helm-installer/README.md
csi-isilon-bundle-2.11.0/dell-csi-helm-installer/csi-install.sh
csi-isilon-bundle-2.11.0/dell-csi-helm-installer/images.manifest
csi-isilon-bundle-2.11.0/dell-csi-helm-installer/verify.sh
csi-isilon-bundle-2.11.0/dell-csi-helm-installer/csi-uninstall.sh
csi-isilon-bundle-2.11.0/dell-csi-helm-installer/csi-offline-bundle.sh

*
* Complete

Offline bundle file is: /root/workspacecsm/csi-powerscale/csi-isilon-bundle-2.11.0.tar.gz

