### PR TITLE
Adding new k8s version support in helm-chart & csm-operator

### DIFF
--- a/dell-csi-helm-installer/verify-csi-isilon.sh
+++ b/dell-csi-helm-installer/verify-csi-isilon.sh
@@ -14,8 +14,8 @@
 #
 # verify-csi-isilon method
 function verify-csi-isilon() {
-  verify_k8s_versions "1.21" "1.30"
-  verify_openshift_versions "4.15" "4.16"
+  verify_k8s_versions "1.25" "1.31"
+  verify_openshift_versions "4.16" "4.17"
   verify_namespace "${NS}"
   verify_required_secrets "${RELEASE}-creds"
   verify_optional_secrets "${RELEASE}-certs"


### PR DESCRIPTION
# Description
Updating support for K8s versions and OCP versions. K8s v1.31 support added and OCP v4.17 support added. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1435 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

Installed driver and ran cert-csi test 
[k8s-pscale-1.31-cert-csi.txt](https://github.com/user-attachments/files/17217655/k8s-pscale-1.31-cert-csi.txt)
![image](https://github.com/user-attachments/assets/c903e913-ee9f-495f-a352-ffaf22cb9417)

