### PR TITLE
Add Check for Hard Limit in ControllerExpandVolume

### DIFF
--- a/service/controller.go
+++ b/service/controller.go
@@ -1046,14 +1046,15 @@ func (s *service) ControllerExpandVolume(
 		quotaSizeAdvisory := quota.Thresholds.Advisory
 		quotaSoftGrace := quota.Thresholds.SoftGrace
 
-		if quotaSizeHard == 0 {
-			return nil, status.Errorf(codes.Internal, "Hard limit is 0, cannot proceed with volume expansion")
-		}
-
 		if requiredBytes <= quotaSizeHard {
 			// volume capacity is larger than or equal to the target capacity, return OK
 			return &csi.ControllerExpandVolumeResponse{CapacityBytes: quotaSizeHard, NodeExpansionRequired: false}, nil
 		}
+
+		if quotaSizeHard == 0 {
+			return nil, status.Errorf(codes.Internal, "Hard limit is 0, cannot proceed with volume expansion")
+		}
+
 		updatedSoftLimit := quotaSizeSoft * (requiredBytes / quotaSizeHard)
 		updatedAdvisoryLimit := quotaSizeAdvisory * (requiredBytes / quotaSizeHard)
 

--- a/service/controller.go
+++ b/service/controller.go
@@ -1046,6 +1046,10 @@ func (s *service) ControllerExpandVolume(
 		quotaSizeAdvisory := quota.Thresholds.Advisory
 		quotaSoftGrace := quota.Thresholds.SoftGrace
 
+		if quotaSizeHard == 0 {
+			return nil, status.Errorf(codes.Internal, "Hard limit is 0, cannot proceed with volume expansion")
+		}
+
 		if requiredBytes <= quotaSizeHard {
 			// volume capacity is larger than or equal to the target capacity, return OK
 			return &csi.ControllerExpandVolumeResponse{CapacityBytes: quotaSizeHard, NodeExpansionRequired: false}, nil


### PR DESCRIPTION
# Description
Add Check for Hard Limit Not Set to 0 in ControllerExpandVolume

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1726

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [X] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
1) Reproduced the issue by installing the driver, creating a filesystem, removing the hard limit from the array, and attempting to expand the volume. The error message observed was: panic: runtime error: integer divide by zero.
2) Built a new image with the fix and installed the driver with this new image.
3) Attempted to expand the filesystem by removing the hard limit from the array. The following error message was observed: "Hard limit is 0, cannot proceed with volume expansion."
