### PR TITLE
Update CreateVolume to conform to CSI 1.6

### DIFF
--- a/service/controller.go
+++ b/service/controller.go
@@ -563,6 +563,18 @@ func (s *service) CreateVolume(
 		log.Debugf("id of the corresponding nfs export of existing volume '%s' has been resolved to '%d'", req.GetName(), exportID)
 		if exportID != 0 {
 			if foundVol || isROVolumeFromSnapshot {
+				// When Quota is enabled, validate the requested size against the quota
+				if s.opts.QuotaEnabled {
+					quota, err := isiConfig.isiSvc.GetVolumeQuota(ctx, req.GetName(), exportID, accessZone)
+					if err != nil {
+						return nil, status.Errorf(codes.NotFound, "can't find quota for volume '%s': %s", req.GetName(), err.Error())
+					}
+
+					if sizeInBytes != quota.Thresholds.Hard {
+						return nil, status.Errorf(codes.AlreadyExists, "volume '%s' exists, but at different size than requested", req.GetName())
+					}
+				}
+
 				return s.getCreateVolumeResponse(ctx, exportID, req.GetName(), path, export.Zone, sizeInBytes, azServiceIP, rootClientEnabled, sourceSnapshotID, sourceVolumeID, clusterName), nil
 			}
 			// in case the export exists but no related volume (directory)

--- a/service/features/controller_create_delete_volume.feature
+++ b/service/features/controller_create_delete_volume.feature
@@ -79,6 +79,8 @@ Feature: Isilon CSI interface
     Examples:
      | getVolumeError           | getExportError            | serverError1         | serverError2           | errormsg                                 |
      | "VolumeExists"           | "ExportExists"            | "none"               | "none"                 | "none"                                   |
+     | "VolumeExists"           | "ExportExists"            | "QuotaNotFoundError" | "none"                 | "can't find quota for volume"                                   |
+     | "VolumeExists"           | "ExportExists"            | "QuotaDifferentSize" | "none"                 | "but at different size than requested"   |
      | "VolumeNotExistError"    | "ExportNotFoundError"     | "none"               | "none"                 | "none"                                   |
      | "VolumeExists"           | "ExportNotFoundError"     | "none"               | "none"                 | "the export may not be ready yet"        |
      | "VolumeNotExistError"    | "ExportExists"            | "none"               | "none"                 | "none"                                   |

--- a/service/mock/quota/get_quota_by_id_4gb.txt
+++ b/service/mock/quota/get_quota_by_id_4gb.txt
@@ -1,0 +1,36 @@
+{
+  "quotas": [
+    {
+      "container": true,
+      "enforced": true,
+      "id": "WACnAAEAAAAAAAAAAAAAQBUPAAAAAAAA",
+      "include_snapshots": false,
+      "linked": false,
+      "notifications": "default",
+      "path": "/ifs/data/csi/Hui/k8s-37fae6e3fa",
+      "persona": null,
+      "ready": true,
+      "thresholds": {
+        "advisory": null,
+        "advisory_exceeded": false,
+        "advisory_last_exceeded": null,
+        "hard": 4294967296,
+        "hard_exceeded": false,
+        "hard_last_exceeded": null,
+        "percent_advisory": null,
+        "percent_soft": null,
+        "soft": null,
+        "soft_exceeded": false,
+        "soft_grace": null,
+        "soft_last_exceeded": null
+      },
+      "thresholds_include_overhead": false,
+      "type": "directory",
+      "usage": {
+        "inodes": 1,
+        "logical": 0,
+        "physical": 2048
+      }
+    }
+  ]
+}

--- a/service/mock/quota/get_quota_by_id_8gb.txt
+++ b/service/mock/quota/get_quota_by_id_8gb.txt
@@ -1,0 +1,36 @@
+{
+  "quotas": [
+    {
+      "container": true,
+      "enforced": true,
+      "id": "WACnAAEAAAAAAAAAAAAAQBUPAAAAAAAA",
+      "include_snapshots": false,
+      "linked": false,
+      "notifications": "default",
+      "path": "/ifs/data/csi/Hui/k8s-37fae6e3fa",
+      "persona": null,
+      "ready": true,
+      "thresholds": {
+        "advisory": null,
+        "advisory_exceeded": false,
+        "advisory_last_exceeded": null,
+        "hard": 8589934592,
+        "hard_exceeded": false,
+        "hard_last_exceeded": null,
+        "percent_advisory": null,
+        "percent_soft": null,
+        "soft": null,
+        "soft_exceeded": false,
+        "soft_grace": null,
+        "soft_last_exceeded": null
+      },
+      "thresholds_include_overhead": false,
+      "type": "directory",
+      "usage": {
+        "inodes": 1,
+        "logical": 0,
+        "physical": 2048
+      }
+    }
+  ]
+}

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -872,6 +872,8 @@ func (f *feature) iInduceError(errtype string) error {
 		stepHandlersErrors.QuotaNotFoundError = true
 	case "InvalidQuotaError":
 		stepHandlersErrors.InvalidQuotaError = true
+	case "QuotaDifferentSize":
+		stepHandlersErrors.QuotaDifferentSize = true
 	case "DeleteVolumeError":
 		stepHandlersErrors.DeleteVolumeError = true
 	case "GetPolicyInternalError":

--- a/service/step_handlers_test.go
+++ b/service/step_handlers_test.go
@@ -61,6 +61,7 @@ var (
 		DeleteQuotaError              bool
 		QuotaNotFoundError            bool
 		InvalidQuotaError             bool
+		QuotaDifferentSize            bool
 		DeleteVolumeError             bool
 		GetJobsInternalError          bool
 		GetPolicyInternalError        bool
@@ -416,7 +417,11 @@ func handleGetQuotaByID(w http.ResponseWriter, _ *http.Request) {
 		w.Write(readFromFile("mock/quota/quota_not_found.txt"))
 		return
 	}
-	w.Write(readFromFile("mock/quota/get_quota_by_id.txt"))
+	mockQuota := "mock/quota/get_quota_by_id_8gb.txt"
+	if stepHandlersErrors.QuotaDifferentSize {
+		mockQuota = "mock/quota/get_quota_by_id_4gb.txt"
+	}
+	w.Write(readFromFile(mockQuota))
 }
 
 // handleGetQuota implements GET /platform/1/quota/quotas?path=/ifs/data/csi-isilon/volume1/
@@ -434,7 +439,7 @@ func handleGetQuotaByPath(w http.ResponseWriter, _ *http.Request) {
 		w.Write(readFromFile("mock/quota/invalid_quota.txt"))
 		return
 	}
-	w.Write(readFromFile("mock/quota/get_quota_by_id.txt"))
+	w.Write(readFromFile("mock/quota/get_quota_by_id_8gb.txt"))
 }
 
 // handleUpdateQuotaByID implements PUT /platform/1/quota/quotas/AABpAQEAAAAAAAAAAAAAQA0AAAAAAAAA


### PR DESCRIPTION
# Description
Enhancements to improve compliance with CSI spec: 1.6.
CreateVolume should fail when requesting to create a volume with already existing name and different capacity


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1896 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

 - [x] Ran csi-santiy and verified that no existing tests are failing and that the CreateVolume test pass
 - [x] Ran cert-csi successfully
