### PR TITLE
Add ListSnapshot to conform to CSI 1.6 Spec

### DIFF
--- a/service/controller.go
+++ b/service/controller.go
@@ -1525,7 +1525,7 @@ func (s *service) ListSnapshots(ctx context.Context, req *csi.ListSnapshotsReque
 	log.Infof("Request received: snapshotID=%s, sourceVolID=%s, startToken=%s, maxEntries=%d", snapshotID, sourceVolID, req.GetStartingToken(), maxEntries)
 
 	if token := req.GetStartingToken(); token != "" {
-		i, err := strconv.ParseInt(token, 10, 32)
+		i, err := strconv.ParseInt(token, 10, 64)
 		if err != nil {
 			log.Errorf("Failed to parse starting token: %s, error=%v", token, err)
 			return nil, status.Error(codes.Aborted, logging.GetMessageWithRunID(runID, "unable to parse StartingToken: %v into uint32", token))

--- a/service/controller_test.go
+++ b/service/controller_test.go
@@ -584,7 +584,7 @@ func TestListSnapshots(t *testing.T) {
 		resp, err := s.ListSnapshots(context.Background(), req)
 		assert.Error(t, err)
 		assert.Equal(t, codes.Internal, status.Code(err))
-		assert.ErrorContains(t, err, "invalid starting token, error: startingToken=10 > len(allSnapshots)=2")
+		assert.ErrorContains(t, err, "invalid starting token, error: startingToken=10 > totalSnapshots=2")
 		assert.Nil(t, resp)
 	})
 

--- a/service/isiService.go
+++ b/service/isiService.go
@@ -776,6 +776,19 @@ func (svc *isiService) GetSnapshot(ctx context.Context, identity string) (isi.Sn
 	return snapshot, nil
 }
 
+func (svc *isiService) GetSnapshots(ctx context.Context) (isi.SnapshotList, error) {
+	// Fetch log handler
+	log := logging.GetRunIDLogger(ctx)
+	log.Debugf("begin getting all the snapshot  for Isilon")
+	var snapshotList isi.SnapshotList
+	var err error
+	if snapshotList, err = svc.client.GetSnapshots(ctx); err != nil {
+		log.Errorf("failed to get snapshots '%s'", err.Error())
+		return nil, err
+	}
+	return snapshotList, nil
+}
+
 func (svc *isiService) GetSnapshotSize(ctx context.Context, isiPath, name string, accessZone string) int64 {
 	// Fetch log handler
 	log := logging.GetRunIDLogger(ctx)
@@ -799,6 +812,21 @@ func (svc *isiService) GetExportWithPathAndZone(ctx context.Context, path, acces
 	var err error
 	if export, err = svc.client.GetExportWithPathAndZone(ctx, path, accessZone); err != nil {
 		log.Error("failed to get export with target path '" + path + "' and access zone '" + accessZone + "': '" + err.Error() + "'")
+		return nil, err
+	}
+
+	return export, nil
+}
+
+func (svc *isiService) GetExportWithPath(ctx context.Context, path string) (isi.Export, error) {
+	// Fetch log handler
+	log := logging.GetRunIDLogger(ctx)
+
+	log.Debugf("begin getting export with target path '%s' for Isilon", path)
+	var export isi.Export
+	var err error
+	if export, err = svc.client.GetExportWithPath(ctx, path); err != nil {
+		log.Error("failed to get export with target path '" + path + "' : '" + err.Error() + "'")
 		return nil, err
 	}
 

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -1018,11 +1018,11 @@ func (f *feature) aValidControllerGetCapabilitiesResponseIsReturned() error {
 			}
 		}
 
-		if f.service.opts.IsHealthMonitorEnabled && count != 9 {
+		if f.service.opts.IsHealthMonitorEnabled && count != 10 {
 			// Set default value
 			f.service.opts.IsHealthMonitorEnabled = false
 			return errors.New("Did not retrieve all the expected capabilities")
-		} else if !f.service.opts.IsHealthMonitorEnabled && count != 7 {
+		} else if !f.service.opts.IsHealthMonitorEnabled && count != 8 {
 			return errors.New("Did not retrieve all the expected capabilities")
 		}
 
@@ -1097,6 +1097,8 @@ func (f *feature) iCallValidateVolumeCapabilitiesWithVoltypeAccess(voltype, acce
 }
 
 func clearErrors() {
+	stepHandlersErrors.counterMutex.Lock()
+	defer stepHandlersErrors.counterMutex.Unlock()
 	stepHandlersErrors.ExportNotFoundError = true
 	stepHandlersErrors.VolumeNotExistError = true
 	stepHandlersErrors.InstancesError = false


### PR DESCRIPTION
# Description
This PR addresses the following CSI Spec 1.6 test scenarios for `ListSnapshot`

- Should return snapshots matching snapshot ID
- Should return empty for non-existent snapshot ID
- Should return snapshots matching source volume ID
- Should return empty for non-existent source volume ID
- Should check presence of new snapshots
- Should return next token for limited entries
- Should return appropriate values


# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1896 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Successfully executed k8s e2e
- [x] Sanity tests for ListSnapshot<img width="1338" height="920" alt="image" src="https://github.com/user-attachments/assets/b2e0c9fd-86ca-4f98-b555-27b5631c9c8f" />
 
