### PR TITLE
Fix NodeGetVolumeStats to conform to CSI 1.6 Spec

### DIFF
--- a/service/controller.go
+++ b/service/controller.go
@@ -1259,7 +1259,7 @@ func (s *service) ControllerPublishVolume(
 		}
 	} else {
 		isiPath = isilonfs.GetIsiPathFromExportPath(exportPath)
-		vol, err := isiConfig.isiSvc.GetVolume(ctx, isiPath, "", volName)
+		vol, err := isiConfig.isiSvc.GetVolumeWithIsiPath(ctx, isiPath, "", volName)
 		if err != nil || vol.Name == "" {
 			return nil, status.Error(codes.Internal,
 				logging.GetMessageWithRunID(runID, "failure checking volume status before controller publish: %s",
@@ -2303,7 +2303,7 @@ func (s *service) ControllerGetVolume(ctx context.Context,
 
 	// Fetch volume details
 	if !abnormal {
-		volume, err = isiConfig.isiSvc.GetVolume(ctx, isiPath, "", volName)
+		volume, err = isiConfig.isiSvc.GetVolumeWithIsiPath(ctx, isiPath, "", volName)
 		if err != nil {
 			abnormal = true
 			message = fmt.Sprintf("error in getting '%s' volume '%v'", volName, err)

--- a/service/features/service.feature
+++ b/service/features/service.feature
@@ -433,12 +433,6 @@ Feature: Isilon CSI interface
       And I call NodeGetVolumeStats with name "volume2=_=_=43=_=_=System=_=_=cluster1"
       Then the error contains "no volume is mounted at path"
 
-    Scenario: NodeGetVolumeStats volume does not exist at path scenario
-      Given a Isilon service
-      When I call Probe
-      And I call NodeGetVolumeStats with name "volume3=_=_=43=_=_=System=_=_=cluster1"
-      Then the error contains "volume3 does not exist at path"
-
     Scenario: NodeGetVolumeStats cluster does not exist scenario
       Given a Isilon service
       When I call Probe

--- a/service/isiService.go
+++ b/service/isiService.go
@@ -414,7 +414,7 @@ func (svc *isiService) GetNFSExportURLForPath(ip string, dirPath string) string 
 	return fmt.Sprintf("%s:%s", ip, dirPath)
 }
 
-func (svc *isiService) GetVolume(ctx context.Context, isiPath, volID, volName string) (isi.Volume, error) {
+func (svc *isiService) GetVolumeWithIsiPath(ctx context.Context, isiPath, volID, volName string) (isi.Volume, error) {
 	// Fetch log handler
 	log := logging.GetRunIDLogger(ctx)
 
@@ -423,6 +423,22 @@ func (svc *isiService) GetVolume(ctx context.Context, isiPath, volID, volName st
 	var vol isi.Volume
 	var err error
 	if vol, err = svc.client.GetVolumeWithIsiPath(ctx, isiPath, volID, volName); err != nil {
+		log.Errorf("failed to get volume '%s'", err)
+		return nil, err
+	}
+
+	return vol, nil
+}
+
+func (svc *isiService) GetVolume(ctx context.Context, volID, volName string) (isi.Volume, error) {
+	// Fetch log handler
+	log := logging.GetRunIDLogger(ctx)
+
+	log.Debugf("begin getting volume with name '%s' for Isilon", volName)
+
+	var vol isi.Volume
+	var err error
+	if vol, err = svc.client.GetVolume(ctx, volID, volName); err != nil {
 		log.Errorf("failed to get volume '%s'", err)
 		return nil, err
 	}
@@ -917,7 +933,7 @@ func (svc *isiService) GetSubDirectoryCount(ctx context.Context, isiPath, direct
 	var totalSubDirectories int64
 	if svc.IsVolumeExistent(ctx, isiPath, "", directory) {
 		// Check if there are any entries for volumes present in snapshot tracking dir
-		dirDetails, err := svc.GetVolume(ctx, isiPath, "", directory)
+		dirDetails, err := svc.GetVolumeWithIsiPath(ctx, isiPath, "", directory)
 		if err != nil {
 			return 0, err
 		}

--- a/service/node.go
+++ b/service/node.go
@@ -477,15 +477,13 @@ func (s *service) NodeGetVolumeStats(
 		return nil, err
 	}
 
-	isVolumeExistentFunc := getIsVolumeExistentFunc(isiConfig)
-	isVolumeExistent := isVolumeExistentFunc(ctx, volName, volPath, "")
-
-	if !isVolumeExistent {
+	isiVol, err := isiConfig.isiSvc.GetVolume(ctx, "", volName)
+	if err != nil || isiVol == nil {
 		return nil, status.Error(codes.NotFound, logging.GetMessageWithRunID(runID, "volume %v does not exist at path %v", volName, volPath))
 	}
 
 	// check whether the original volume is mounted
-	isMounted, err := getIsVolumeMounted(ctx, volName, volPath)
+	isMounted, _ := getIsVolumeMounted(ctx, volName, volPath)
 	if !isMounted {
 		return nil, status.Error(codes.NotFound, logging.GetMessageWithRunID(runID, "no volume is mounted at path: %s", volPath))
 	}

--- a/service/node_test.go
+++ b/service/node_test.go
@@ -18,6 +18,7 @@ package service
 
 import (
 	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 	"reflect"
@@ -258,6 +259,19 @@ func TestNodeGetVolumeStats(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("Volume does not exists", func(t *testing.T) {
+		mockClient.ExpectedCalls = nil
+		mockClient.On("VolumesPath").Return("/path/to/volumes")
+		mockClient.On("Get", anyArgs[0:6]...).Return(fmt.Errorf("not found"))
+		req := &csi.NodeGetVolumeStatsRequest{
+			VolumeId:   "volume-id",
+			VolumePath: "/path/to/volume",
+		}
+		resp, err := s.NodeGetVolumeStats(context.Background(), req)
+		assert.ErrorContains(t, err, "volume volume-id does not exist at path /path/to/volume")
+		assert.Nil(t, resp)
+	})
 }
 
 func TestEphemeralNodePublish(t *testing.T) {

--- a/service/replication.go
+++ b/service/replication.go
@@ -386,7 +386,7 @@ func (s *service) DeleteStorageProtectionGroup(ctx context.Context,
 
 	log.WithFields(fields).Info("Deleting storage protection group")
 
-	volume, err := isiConfig.isiSvc.GetVolume(ctx, isiPath, "", "")
+	volume, err := isiConfig.isiSvc.GetVolumeWithIsiPath(ctx, isiPath, "", "")
 	if err != nil {
 		if e, ok := err.(*isiApi.JSONError); ok {
 			if e.StatusCode != 404 {

--- a/service/service.go
+++ b/service/service.go
@@ -862,7 +862,7 @@ func (s *service) getVolByName(ctx context.Context, isiPath, volName string, isi
 var getVolByNameFunc = func(_ *service, ctx context.Context, isiPath, volName string, isiConfig *IsilonClusterConfig) (isi.Volume, error) {
 	// The `GetVolume` API returns a slice of volumes, but when only passing
 	// in a volume ID, the response will be just the one volume
-	vol, err := isiConfig.isiSvc.GetVolume(ctx, isiPath, "", volName)
+	vol, err := isiConfig.isiSvc.GetVolumeWithIsiPath(ctx, isiPath, "", volName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
# Description
Fix NodeGetVolumeStats to conform to CSI 1.6 Spec.
- Node Service should work
- Node Service should be idempotent

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1896 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ran csi-sanity - 
[csi-powerscale-sanity.log](https://github.com/user-attachments/files/21425152/csi-powerscale-sanity.log)

