### PR TITLE
Update TestPatchNodeLabels

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -1095,13 +1095,7 @@ func (s *service) GetNodeLabelsWithName(nodeName string) (map[string]string, err
 func (s *service) PatchNodeLabels(add map[string]string, remove []string) error {
 	log := logging.GetLogger()
 
-	k8sclientset, err := k8sutils.CreateKubeClientSet(s.opts.KubeConfigPath)
-	if err != nil {
-		log.Errorf("init client failed: '%s'", err.Error())
-		return err
-	}
-
-	node, err := k8sclientset.CoreV1().Nodes().Get(context.TODO(), s.nodeID, v1.GetOptions{})
+	node, err := s.k8sclient.CoreV1().Nodes().Get(context.TODO(), s.nodeID, v1.GetOptions{})
 	if err != nil {
 		log.Errorf("failed to get current node details: '%s'", err.Error())
 		return err
@@ -1133,7 +1127,7 @@ func (s *service) PatchNodeLabels(add map[string]string, remove []string) error 
 		return err
 	}
 
-	node, err = k8sclientset.CoreV1().Nodes().Patch(context.TODO(), s.nodeID, types.StrategicMergePatchType, patchBytes, v1.PatchOptions{})
+	node, err = s.k8sclient.CoreV1().Nodes().Patch(context.TODO(), s.nodeID, types.StrategicMergePatchType, patchBytes, v1.PatchOptions{})
 	if err != nil {
 		log.Errorf("failed to patch node labels: '%s'", err.Error())
 		return err

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -48,7 +48,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func xTestMain(m *testing.M) {
+func TestMain(m *testing.M) {
 	// Set required environment variables for Kubernetes client
 	os.Setenv("KUBERNETES_SERVICE_HOST", "127.0.0.1")
 	os.Setenv("KUBERNETES_SERVICE_PORT", "6443")

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -958,7 +958,8 @@ func TestValidateIsiPath(t *testing.T) {
 	}
 }
 
-func xTestPatchNodeLabels(t *testing.T) {
+func TestPatchNodeLabels(t *testing.T) {
+	type checkFn func(t *testing.T, err error, node *v1.Node)
 	type args struct {
 		add    map[string]string
 		remove []string
@@ -966,7 +967,9 @@ func xTestPatchNodeLabels(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
+		node    *v1.Node
 		wantErr bool
+		check   checkFn
 	}{
 		{
 			name: "success",
@@ -974,7 +977,22 @@ func xTestPatchNodeLabels(t *testing.T) {
 				add:    map[string]string{"label1": "value1"},
 				remove: []string{"label2"},
 			},
+			node: &v1.Node{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-node",
+					Labels: map[string]string{
+						"label2": "value2",
+					},
+				},
+			},
 			wantErr: false,
+			check: func(t *testing.T, err error, node *v1.Node) {
+				assert.NoError(t, err)
+				assert.Contains(t, node.Labels, "label1")
+				assert.Equal(t, "value1", node.Labels["label1"])
+				_, exists := node.Labels["label2"]
+				assert.False(t, exists, "label2 should be removed")
+			},
 		},
 	}
 
@@ -982,7 +1000,8 @@ func xTestPatchNodeLabels(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			s := &service{
 				mode:      "test",
-				k8sclient: fake.NewSimpleClientset(),
+				nodeID:    "test-node",
+				k8sclient: fake.NewSimpleClientset(tt.node),
 			}
 
 			err := s.PatchNodeLabels(tt.args.add, tt.args.remove)

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -48,7 +48,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func TestMain(m *testing.M) {
+func xTestMain(m *testing.M) {
 	// Set required environment variables for Kubernetes client
 	os.Setenv("KUBERNETES_SERVICE_HOST", "127.0.0.1")
 	os.Setenv("KUBERNETES_SERVICE_PORT", "6443")
@@ -1008,6 +1008,12 @@ func TestPatchNodeLabels(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("PatchNodeLabels() error = %v, wantErr %v", err, tt.wantErr)
 			}
+
+			node, err := s.k8sclient.CoreV1().Nodes().Get(context.TODO(), s.nodeID, metav1.GetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+			tt.check(t, err, node)
 		})
 	}
 }


### PR DESCRIPTION
# Description
A few sentences describing the overall goals of the pull request's commits.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

go test -timeout 120s -run ^TestPatchNodeLabels$ github.com/dell/csi-isilon/v2/service -v

=== RUN   TestPatchNodeLabels
=== RUN   TestPatchNodeLabels/success
csi-powerscale logger initiated. This should be called only once.
time="2025-08-08T09:23:49-04:00" level=debug   msg="Node details after patching labels: &Node{ObjectMeta:{test-node      0 0001-01-01 00:00:00 +0000 UTC <nil> <nil> map[label1:value1] map[] [] [] []},Spec:NodeSpec{PodCIDR:,DoNotUseExternalID:,ProviderID:,Unschedulable:false,Taints:[]Taint{},ConfigSource:nil,PodCIDRs:[],},Status:NodeStatus{Capacity:ResourceList{},Allocatable:ResourceList{},Phase:,Conditions:[]NodeCondition{},Addresses:[]NodeAddress{},DaemonEndpoints:NodeDaemonEndpoints{KubeletEndpoint:DaemonEndpoint{Port:0,},},NodeInfo:NodeSystemInfo{MachineID:,SystemUUID:,BootID:,KernelVersion:,OSImage:,ContainerRuntimeVersion:,KubeletVersion:,KubeProxyVersion:,OperatingSystem:,Architecture:,Swap:nil,},Images:[]ContainerImage{},VolumesInUse:[],VolumesAttached:[]AttachedVolume{},Config:nil,RuntimeHandlers:[]NodeRuntimeHandler{},Features:nil,},}" file="/root/csi-powerscale/service/service.go:1136"
--- PASS: TestPatchNodeLabels (0.00s)
    --- PASS: TestPatchNodeLabels/success (0.00s)
PASS
ok  	github.com/dell/csi-isilon/v2/service	0.032s
