### PR TITLE
Updated Access Zone Network Node Label Format

### DIFF
--- a/service/controller.go
+++ b/service/controller.go
@@ -1860,12 +1860,12 @@ func (s *service) getIpsFromAZNetworkLabel(ctx context.Context, nodeID, azNetwor
 			log.Debugf("Key: %s, Value: %s\n", key, value)
 
 			// getting network interface IP, subnet, and export IP
-			azNetworkIp, azNetworkSubnet, exportIp := match[1], match[2], match[3]
-			log.Debugf("AZNetwork IP %s, AZNetwork subnet %s, export IP %s from node label", azNetworkIp, azNetworkSubnet, exportIp)
+			azNetworkIP, azNetworkSubnet, exportIP := match[1], match[2], match[3]
+			log.Debugf("AZNetwork IP %s, AZNetwork subnet %s, export IP %s from node label", azNetworkIP, azNetworkSubnet, exportIP)
 
 			// if matching, return the IP(s)
-			if azNetwork == fmt.Sprintf("%s/%s", azNetworkIp, azNetworkSubnet) {
-				ips = append(ips, exportIp)
+			if azNetwork == fmt.Sprintf("%s/%s", azNetworkIP, azNetworkSubnet) {
+				ips = append(ips, exportIP)
 			}
 		}
 	}

--- a/service/controller_test.go
+++ b/service/controller_test.go
@@ -1855,7 +1855,7 @@ func TestControllerUnpublishVolume(t *testing.T) {
 				NodeId:   identifiers.DummyHostNodeID,
 			},
 			nodeLabels: map[string]string{
-				"csi-isilon.dellemc.com/az-10.0.0.0-24-10.0.0.1": "true",
+				"csi-isilon.dellemc.com/az-10.0.0.0-32-10.0.0.1": "true",
 			},
 			wantErr: true,
 		},

--- a/service/controller_test.go
+++ b/service/controller_test.go
@@ -1616,31 +1616,33 @@ func TestGetIpsFromAZNetworkLabel(t *testing.T) {
 		{
 			name:      "successful execution",
 			nodeID:    "nodename=#=#=localhost=#=#=127.0.0.1",
-			azNetwork: "10.0.0.1/24",
+			azNetwork: "192.168.1.0/24",
 			nodeLabels: map[string]string{
-				"csi-isilon.dellemc.com/aznetwork-10.0.0.1_24": "192.168.1.1-192.168.1.2",
+				"csi-isilon.dellemc.com/az-192.168.1.0-24-192.168.1.1": "true",
+				"csi-isilon.dellemc.com/az-192.168.1.0-24-192.168.1.2": "true",
 			},
 			expectedIPs: []string{"192.168.1.1", "192.168.1.2"},
 		},
 		{
 			name:        "node ID parsing error",
 			nodeID:      "invalid-node-id",
-			azNetwork:   "10.0.0.1/24",
+			azNetwork:   "192.168.1.0/24",
 			expectedErr: fmt.Errorf("node ID '%s' cannot match the expected '^(.+)=#=#=(.+)=#=#=(.+)$' pattern", "invalid-node-id"),
 		},
 		{
 			name:        "node labels retrieval error",
 			nodeID:      "nodename=#=#=localhost=#=#=127.0.0.1",
-			azNetwork:   "10.0.0.1/24",
+			azNetwork:   "192.168.1.0/24",
 			expectedIPs: []string{},
-			expectedErr: fmt.Errorf("failed to match AZNetwork to get IPs for export %s", "10.0.0.1/24"),
+			expectedErr: fmt.Errorf("failed to match AZNetwork to get IPs for export %s", "192.168.1.0/24"),
 		},
 		{
 			name:      "no matching AZNetwork label",
 			nodeID:    "nodename=#=#=localhost=#=#=127.0.0.1",
 			azNetwork: "10.0.0.1/24",
 			nodeLabels: map[string]string{
-				"csi-isilon.dellemc.com/aznetwork-10.0.0.2_24": "192.168.1.1-192.168.1.2",
+				"csi-isilon.dellemc.com/az-192.168.1.0-24-192.168.1.1": "true",
+				"csi-isilon.dellemc.com/az-192.168.1.0-24-192.168.1.2": "true",
 			},
 			expectedIPs: []string{},
 			expectedErr: fmt.Errorf("failed to match AZNetwork to get IPs for export %s", "10.0.0.1/24"),
@@ -1648,10 +1650,10 @@ func TestGetIpsFromAZNetworkLabel(t *testing.T) {
 		{
 			name:        "empty node labels",
 			nodeID:      "nodename=#=#=localhost=#=#=127.0.0.1",
-			azNetwork:   "10.0.0.1/24",
+			azNetwork:   "192.168.1.0/24",
 			nodeLabels:  map[string]string{},
 			expectedIPs: []string{},
-			expectedErr: fmt.Errorf("failed to match AZNetwork to get IPs for export %s", "10.0.0.1/24"),
+			expectedErr: fmt.Errorf("failed to match AZNetwork to get IPs for export %s", "192.168.1.0/24"),
 		},
 		{
 			name:        "error in getIpsFromAZNetworkLabel",
@@ -1723,7 +1725,7 @@ func TestControllerPublishVolume(t *testing.T) {
 				},
 			},
 			nodeLabels: map[string]string{
-				"csi-isilon.dellemc.com/aznetwork-10.0.0.0_24": "10.0.0.1",
+				"csi-isilon.dellemc.com/az-10.0.0.0-24-10.0.0.1": "true",
 			},
 			wantErr: true,
 		},
@@ -1853,7 +1855,7 @@ func TestControllerUnpublishVolume(t *testing.T) {
 				NodeId:   identifiers.DummyHostNodeID,
 			},
 			nodeLabels: map[string]string{
-				"csi-isilon.dellemc.com/aznetwork-10.247.0.0_24": "10.0.0.1",
+				"csi-isilon.dellemc.com/az-10.0.0.0-24-10.0.0.1": "true",
 			},
 			wantErr: true,
 		},

--- a/service/node.go
+++ b/service/node.go
@@ -802,17 +802,9 @@ func (s *service) ReconcileNodeAzLabels(ctx context.Context) error {
 				if err != nil {
 					log.Errorf("encountered error while parsing IP address %v", addr)
 				} else {
-					sanitizedIP := strings.ReplaceAll(cnet.String(), "/", "_")
-					key := fmt.Sprintf("%s/aznetwork-%s", constants.PluginName, sanitizedIP)
-					if val, ok := labelsToAdd[key]; ok {
-						if len(val)+len(ip.String()) < 63 {
-							labelsToAdd[key] = labelsToAdd[key] + "-" + ip.String()
-						} else {
-							log.Warnf("label value will exceed 63 characters, skipping update of this label %s", key)
-						}
-					} else {
-						labelsToAdd[key] = ip.String()
-					}
+					sanitizedNet := strings.ReplaceAll(cnet.String(), "/", "-")
+					key := fmt.Sprintf("%s/az-%s-%s", constants.PluginName, sanitizedNet, ip.String())
+					labelsToAdd[key] = "true"
 					log.Debugf("discovered label %s -> %s", key, labelsToAdd[key])
 				}
 			}
@@ -826,7 +818,7 @@ func (s *service) ReconcileNodeAzLabels(ctx context.Context) error {
 
 	labelsToRemove := make([]string, 0)
 	for k := range labels {
-		if strings.HasPrefix(k, constants.PluginName+"/aznetwork-") {
+		if strings.HasPrefix(k, constants.PluginName+"/az-") {
 			if _, ok := labelsToAdd[k]; !ok {
 				labelsToRemove = append(labelsToRemove, k)
 			}

--- a/service/node_test.go
+++ b/service/node_test.go
@@ -1174,24 +1174,7 @@ func TestReconcileNodeAzLabels(t *testing.T) {
 			},
 			nodeLabels: map[string]string{},
 			expectedLabelsToAdd: map[string]string{
-				"csi-isilon.dellemc.com/aznetwork-192.168.1.0_24": "192.168.1.1",
-			},
-			expectedLabelsToRemove: []string{},
-			wantErr:                false,
-		},
-		{
-			name: "update existing labels",
-			addrs: []net.Addr{
-				&net.IPNet{
-					IP:   net.ParseIP("192.168.1.1").To4(),
-					Mask: net.CIDRMask(24, 32),
-				},
-			},
-			nodeLabels: map[string]string{
-				"csi-isilon.dellemc.com/aznetwork-192.168.1.0_24": "192.168.1.2",
-			},
-			expectedLabelsToAdd: map[string]string{
-				"csi-isilon.dellemc.com/aznetwork-192.168.1.0_24": "192.168.1.1",
+				"csi-isilon.dellemc.com/az-192.168.1.0-24-192.168.1.1": "true",
 			},
 			expectedLabelsToRemove: []string{},
 			wantErr:                false,
@@ -1200,43 +1183,16 @@ func TestReconcileNodeAzLabels(t *testing.T) {
 			name:  "remove labels",
 			addrs: []net.Addr{},
 			nodeLabels: map[string]string{
-				"csi-isilon.dellemc.com/aznetwork-192.168.1.0_24": "192.168.1.1",
+				"csi-isilon.dellemc.com/az-192.168.1.0-24-192.168.1.1": "true",
 			},
 			expectedLabelsToAdd: map[string]string{},
 			expectedLabelsToRemove: []string{
-				"csi-isilon.dellemc.com/aznetwork-192.168.1.0_24",
+				"csi-isilon.dellemc.com/az-192.168.1.0-24-192.168.1.1",
 			},
 			wantErr: false,
 		},
 		{
-			name: "multiple addresses in same network limits to 63 characters",
-			addrs: []net.Addr{
-				&net.IPNet{
-					IP:   net.ParseIP("192.168.100.100").To4(),
-					Mask: net.CIDRMask(24, 32),
-				},
-				&net.IPNet{
-					IP:   net.ParseIP("192.168.100.101").To4(),
-					Mask: net.CIDRMask(24, 32),
-				},
-				&net.IPNet{
-					IP:   net.ParseIP("192.168.100.102").To4(),
-					Mask: net.CIDRMask(24, 32),
-				},
-				&net.IPNet{
-					IP:   net.ParseIP("192.168.100.103").To4(),
-					Mask: net.CIDRMask(24, 32),
-				},
-			},
-			nodeLabels: map[string]string{},
-			expectedLabelsToAdd: map[string]string{
-				"csi-isilon.dellemc.com/aznetwork-192.168.100.0_24": "192.168.100.100-192.168.100.101-192.168.100.102-192.168.100.103",
-			},
-			expectedLabelsToRemove: []string{},
-			wantErr:                false,
-		},
-		{
-			name: "too many addresses exceeding label limits",
+			name: "multiple addresses in same network",
 			addrs: []net.Addr{
 				&net.IPNet{
 					IP:   net.ParseIP("192.168.100.100").To4(),
@@ -1261,7 +1217,11 @@ func TestReconcileNodeAzLabels(t *testing.T) {
 			},
 			nodeLabels: map[string]string{},
 			expectedLabelsToAdd: map[string]string{
-				"csi-isilon.dellemc.com/aznetwork-192.168.100.0_24": "192.168.100.100-192.168.100.101-192.168.100.102-192.168.100.103",
+				"csi-isilon.dellemc.com/az-192.168.100.0-24-192.168.100.100": "true",
+				"csi-isilon.dellemc.com/az-192.168.100.0-24-192.168.100.101": "true",
+				"csi-isilon.dellemc.com/az-192.168.100.0-24-192.168.100.102": "true",
+				"csi-isilon.dellemc.com/az-192.168.100.0-24-192.168.100.103": "true",
+				"csi-isilon.dellemc.com/az-192.168.100.0-24-192.168.100.104": "true",
 			},
 			expectedLabelsToRemove: []string{},
 			wantErr:                false,
@@ -1301,7 +1261,10 @@ func TestReconcileNodeAzLabels(t *testing.T) {
 			},
 			nodeLabels: map[string]string{},
 			expectedLabelsToAdd: map[string]string{
-				"csi-isilon.dellemc.com/aznetwork-192.168.100.0_24": "192.168.100.100-192.168.100.101-192.168.100.102-192.168.100.104",
+				"csi-isilon.dellemc.com/az-192.168.100.0-24-192.168.100.100": "true",
+				"csi-isilon.dellemc.com/az-192.168.100.0-24-192.168.100.101": "true",
+				"csi-isilon.dellemc.com/az-192.168.100.0-24-192.168.100.102": "true",
+				"csi-isilon.dellemc.com/az-192.168.100.0-24-192.168.100.104": "true",
 			},
 			expectedLabelsToRemove: []string{},
 			wantErr:                false,
@@ -1315,7 +1278,7 @@ func TestReconcileNodeAzLabels(t *testing.T) {
 				},
 			},
 			expectedLabelsToAdd: map[string]string{
-				"csi-isilon.dellemc.com/aznetwork-192.168.1.0_24": "192.168.1.1",
+				"csi-isilon.dellemc.com/az-192.168.1.0-24-192.168.1.1": "true",
 			},
 			expectedLabelsToRemove: []string{},
 			getNodeLabelsErr:       errors.New("permission denied"),
@@ -1330,7 +1293,7 @@ func TestReconcileNodeAzLabels(t *testing.T) {
 				},
 			},
 			expectedLabelsToAdd: map[string]string{
-				"csi-isilon.dellemc.com/aznetwork-192.168.1.0_24": "192.168.1.1",
+				"csi-isilon.dellemc.com/az-192.168.1.0-24-192.168.1.1": "true",
 			},
 			expectedLabelsToRemove: []string{},
 			patchNodeLabelsErr:     errors.New("injected failed"),

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -1133,7 +1133,7 @@ func TestSetAZReconcileInterval(t *testing.T) {
 func TestService_reconcileNodeAzLabels(t *testing.T) {
 	nodeName := "test-node"
 	nodeLabels := map[string]string{
-		"csi-isilon.dellemc.com/aznetwork-10.0.0.0_24": "10.0.0.1",
+		"csi-isilon.dellemc.com/az-10.0.0.0-24-10.0.0.1": "true",
 	}
 
 	k8sclient := fake.NewSimpleClientset(&v1.Node{


### PR DESCRIPTION
# Description
- Updated AzNetwork node label format to eliminate limitation of 63 chars with the previous design
E.g.
```
csi-isilon.dellemc.com/az-192.168.1.0-24-192.168.1.1
```

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1991 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested parsing new node labels (single IP and multiple IPs)
